### PR TITLE
feat(orca): per-instance tmux server isolation (D8) + dot/colon sanitization

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -71,11 +71,12 @@ orca --lead claude --worker codex --workers 3 --workflow code
 - [ ] Naming/identification scheme for multiple instances under same dir
 - [ ] `orca-stop` / `orca-ls` adapt to multi-instance
 
-**tmux server isolation** (D8)
-- [ ] `start.sh` / `stop.sh` use `tmux -L orca-<dirname>` for a dedicated per-instance server
-- [ ] `stop.sh` does `tmux -L ... kill-server` (server only owns this one session, kill = clean env)
-- [ ] Verify `tmux-bridge` auto-detects via `$TMUX` (already supported, no change needed)
-- [ ] No migration logic for existing users on shared server — documented in release notes only
+**tmux server isolation** (D8) — landed in PR #4
+- [x] `start.sh` / `stop.sh` use `tmux -L orca-<dirname>` for a dedicated per-instance server
+- [x] `stop.sh` does `tmux -L ... kill-server` (server only owns this one session, kill = clean env)
+- [x] Verify `tmux-bridge` auto-detects via `$TMUX` (zero changes needed; out-of-pane `name` calls pass `TMUX_BRIDGE_SOCKET`)
+- [x] Pre-D8 legacy session cleanup in `stop.sh` (orphan sessions on user's main tmux are detected + removed alongside dedicated)
+- [x] Sanitize `.` and `:` in dir basename (pre-existing bug surfaced during D8 smoke test)
 
 ## P1: Workflow Skills
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -35,6 +35,7 @@ Known issues:
 | D5 | Worktree timing | On-demand at dispatch time | User may need only 1 worker |
 | D6 | Task dependencies | B first (task files + blocked_by) → simplify to A (pure lead judgment) | Start with guardrails, remove if lead is smart enough |
 | D7 | Multi-instance per dir | TBD — direction: Claude Code resume-style picker (list existing + "new") | Current `orca-<dirname>` collides on re-run; explicit `--name` flag rejected as too manual |
+| D8 | tmux server scope | Per-instance dedicated server via `tmux -L orca-<dirname>` | User's main tmux server caches stale env globally; sharing it pollutes user state. Per-instance server: stop=kill server=clean env, start=fresh fork from current shell. Overhead ~5MB/instance, negligible. See [docs/troubleshooting/tmux-server-stale-env.md](docs/troubleshooting/tmux-server-stale-env.md) |
 
 ## Target Architecture
 
@@ -69,6 +70,12 @@ orca --lead claude --worker codex --workers 3 --workflow code
 - [ ] Re-running `orca` in a dir with existing session(s): prompt to attach existing or start new (Claude Code resume-style)
 - [ ] Naming/identification scheme for multiple instances under same dir
 - [ ] `orca-stop` / `orca-ls` adapt to multi-instance
+
+**tmux server isolation** (D8)
+- [ ] `start.sh` / `stop.sh` use `tmux -L orca-<dirname>` for a dedicated per-instance server
+- [ ] `stop.sh` does `tmux -L ... kill-server` (server only owns this one session, kill = clean env)
+- [ ] Verify `tmux-bridge` auto-detects via `$TMUX` (already supported, no change needed)
+- [ ] No migration logic for existing users on shared server — documented in release notes only
 
 ## P1: Workflow Skills
 

--- a/docs/troubleshooting/tmux-server-stale-env.md
+++ b/docs/troubleshooting/tmux-server-stale-env.md
@@ -1,0 +1,114 @@
+# tmux server caches stale env across orca restarts
+
+## Symptom
+
+You edit `~/.bash_profile` (or `~/.zshrc`), comment out an `export FOO=...`,
+open a brand-new terminal, run `orca-stop`, then `orca` again — and inside the
+new orca panes `echo $FOO` still prints the old value.
+
+This persists across:
+- New terminal windows (fresh login shell, profile re-sourced)
+- `orca-stop` followed by `orca`
+- Reboots of the orca CLI agents (claude / codex)
+
+## Root cause
+
+Two facts compound:
+
+1. **Child processes inherit env at fork time, not at config-edit time.** Once a
+   process is running, modifying the file that originally set its env vars has
+   no effect — the env is a snapshot.
+2. **tmux server is long-lived.** The first time you run `tmux ...` after boot,
+   tmux spawns a *server* process that survives until you kill it. Every later
+   `tmux` invocation is a *client* that talks to that same server. New
+   sessions, new windows, new panes are all forked from the server's
+   environment, **not** from the client shell's environment.
+
+So the chain is:
+
+```
+First tmux call ever:
+  login shell (profile sourced, FOO=old)
+    └─ tmux server forked   ← env snapshot taken HERE, FOO=old cached forever
+         └─ session A
+              └─ pane shell (inherits FOO=old)
+
+Months later, you edit profile and remove FOO:
+  new login shell (FOO unset)
+    └─ tmux client → talks to existing server (still has FOO=old)
+         └─ new session B
+              └─ pane shell (inherits FOO=old from server)   ← surprise
+```
+
+You can confirm this with:
+
+```bash
+tmux show-environment -g | grep FOO
+```
+
+The server's `-g` (global) environment is what gets inherited by all new
+sessions, and it was frozen at server-spawn time.
+
+## Why orca makes this worse
+
+orca shares the user's main tmux server. So:
+
+- env vars set ages ago for unrelated reasons leak into orca panes
+- env vars orca *does* want to refresh (e.g. you just rotated an API key in
+  your profile) get masked by the server's stale copy
+- `orca-stop` only kills the *session*, not the server, so it doesn't help
+
+## What orca does about it
+
+Orca uses a **per-instance dedicated tmux server** via `tmux -L orca-<dirname>`
+(see PLAN.md decision D8).
+
+- `orca` (start.sh) → starts a new server if none exists for this dir, then
+  forks the session from *that* server's env, which was just inherited from
+  your current login shell
+- `orca-stop` → kills the dedicated server entirely (it only owns one session
+  anyway), wiping all cached env
+
+Net effect: `orca-stop && orca` always picks up the latest profile state. No
+magic, no env-var whitelist, no auto-sync — just a fresh fork chain.
+
+## Workaround for the user's main tmux server
+
+If you hit this in your *own* tmux setup (outside of orca), you have three
+options ordered by blast radius:
+
+1. **Surgical** — remove just the stale var from the server's global env:
+   ```bash
+   tmux set-environment -gu FOO
+   ```
+   New sessions (existing sessions/panes are unaffected since their pane
+   shells already inherited).
+
+2. **Refresh the server's env from your current shell** for a known set of
+   vars:
+   ```bash
+   tmux set-environment -g FOO "$FOO"
+   ```
+
+3. **Nuclear** — kill the entire tmux server, losing every session:
+   ```bash
+   tmux kill-server
+   ```
+
+None of these affect already-running processes inside panes; those need to be
+restarted to pick up new env.
+
+## Why orca doesn't try to auto-sync env
+
+We considered making orca diff the user's shell env against the server's `-g`
+env on each start and patch the differences. Rejected because:
+
+- Choosing *which* vars to sync requires either a brittle whitelist or
+  syncing everything (which pollutes tmux internal vars and can break things).
+- Already-running CLI agents (claude/codex) wouldn't see the new env anyway —
+  they'd need to be restarted, defeating the point of "no-restart sync".
+- It introduces magic that contradicts standard Unix behavior, making the
+  system harder to reason about.
+
+The dedicated-server approach gives the same end-user guarantee
+(`stop && start` = fresh env) with zero magic.

--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 SESSION="orca-$(basename "$(pwd)")"
+# Per-instance dedicated tmux server (D8): isolates orca from the user's main
+# tmux server so stop=kill-server gives a clean env on next start, and orca
+# never pollutes / inherits stale env from the user's long-lived server.
+SOCKET="$SESSION"
+TMUX_CMD="tmux -L $SOCKET"
 CODER_BIN="${1:-codex}"
 CODER_ARGS="--sandbox danger-full-access -a on-request -c features.codex_hooks=true"
 CODER_CMD="$CODER_BIN $CODER_ARGS"
@@ -24,8 +29,8 @@ if ! command -v "$CODER_BIN" &>/dev/null; then
 fi
 
 # --- Reattach if exists ---
-if tmux has-session -t "$SESSION" 2>/dev/null; then
-  tmux attach -t "$SESSION"
+if $TMUX_CMD has-session -t "$SESSION" 2>/dev/null; then
+  $TMUX_CMD attach -t "$SESSION"
   exit 0
 fi
 
@@ -39,41 +44,45 @@ echo "  Worker: $CODER_CMD"
 echo "  Dir:    $WORKDIR"
 
 # Create session with lead pane (left)
-tmux new-session -d -s "$SESSION" -n main -c "$WORKDIR"
+$TMUX_CMD new-session -d -s "$SESSION" -n main -c "$WORKDIR"
 
 # Split worker pane (right, 50% width)
-tmux split-window -h -t "$SESSION:main" -c "$WORKDIR"
+$TMUX_CMD split-window -h -t "$SESSION:main" -c "$WORKDIR"
 
 # --- Even layout ---
-tmux select-layout -t "$SESSION:main" even-horizontal
+$TMUX_CMD select-layout -t "$SESSION:main" even-horizontal
 
 # --- tmux config ---
-tmux set-option -t "$SESSION" mode-keys vi
-tmux set-option -t "$SESSION" mouse on
-tmux bind-key Space select-layout even-horizontal
+$TMUX_CMD set-option -t "$SESSION" mode-keys vi
+$TMUX_CMD set-option -t "$SESSION" mouse on
+$TMUX_CMD bind-key Space select-layout even-horizontal
 # Pass through Kitty keyboard protocol (Ghostty/WezTerm/Kitty) so inner CLIs
 # can negotiate Shift+Enter etc. Without this tmux strips the modifiers.
-tmux set-option -gs extended-keys on
+$TMUX_CMD set-option -gs extended-keys on
 # Idempotent append: tmux's -ga doesn't dedupe; multiple orca starts would
 # pile up duplicate entries.
-if ! tmux show-options -gs terminal-features 2>/dev/null | grep -q ':extkeys'; then
-  tmux set-option -ga terminal-features ',*:extkeys'
+if ! $TMUX_CMD show-options -gs terminal-features 2>/dev/null | grep -q ':extkeys'; then
+  $TMUX_CMD set-option -ga terminal-features ',*:extkeys'
 fi
 
 # --- Name panes (session-prefixed for multi-instance isolation) ---
 LEAD_LABEL="${SESSION}-lead"
 CODER_LABEL="${SESSION}-coder"
-tmux-bridge name "$SESSION:main.0" "$LEAD_LABEL"
-tmux-bridge name "$SESSION:main.1" "$CODER_LABEL"
+# tmux-bridge auto-detects the socket via $TMUX inside panes, but `name` is
+# called from this script (outside any pane), so pass socket explicitly.
+# Ask tmux for its actual socket path (portable across macOS / Linux).
+SOCKET_PATH=$($TMUX_CMD display-message -p -t "$SESSION" '#{socket_path}')
+TMUX_BRIDGE_SOCKET="$SOCKET_PATH" tmux-bridge name "$SESSION:main.0" "$LEAD_LABEL"
+TMUX_BRIDGE_SOCKET="$SOCKET_PATH" tmux-bridge name "$SESSION:main.1" "$CODER_LABEL"
 
 # --- Inject env ---
-tmux send-keys -t "$SESSION:main.0" "export ORCA=1 ORCA_PEER=$CODER_LABEL" Enter
-tmux send-keys -t "$SESSION:main.1" "export ORCA=1 ORCA_PEER=$LEAD_LABEL" Enter
+$TMUX_CMD send-keys -t "$SESSION:main.0" "export ORCA=1 ORCA_PEER=$CODER_LABEL" Enter
+$TMUX_CMD send-keys -t "$SESSION:main.1" "export ORCA=1 ORCA_PEER=$LEAD_LABEL" Enter
 
 # --- Launch agents ---
-tmux send-keys -t "$SESSION:main.0" "claude" Enter
+$TMUX_CMD send-keys -t "$SESSION:main.0" "claude" Enter
 # Codex: pass $orca as initial prompt to auto-activate skill
-tmux send-keys -t "$SESSION:main.1" "$CODER_CMD '\$orca'" Enter
+$TMUX_CMD send-keys -t "$SESSION:main.1" "$CODER_CMD '\$orca'" Enter
 
 # --- /clear re-activation monitor ---
 # After Codex /clear, monitor detects welcome screen and inputs $orca
@@ -81,14 +90,14 @@ tmux send-keys -t "$SESSION:main.1" "$CODER_CMD '\$orca'" Enter
 _skill_monitor() {
   set +e
   local session="$1" pane="$2"
-  while tmux has-session -t "$session" 2>/dev/null; do
+  while $TMUX_CMD has-session -t "$session" 2>/dev/null; do
     local out banner
-    out=$(tmux capture-pane -p -t "$pane" 2>/dev/null \
+    out=$($TMUX_CMD capture-pane -p -t "$pane" 2>/dev/null \
       | perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g') || true
     banner=$(echo "$out" | grep -c '>_ OpenAI Codex')
     if [ "$banner" -gt 0 ] && ! echo "$out" | grep -q '\$orca'; then
       sleep 2
-      tmux send-keys -l -t "$pane" '$orca'
+      $TMUX_CMD send-keys -l -t "$pane" '$orca'
     fi
     sleep 3
   done
@@ -105,7 +114,7 @@ _skill_monitor "$SESSION" "$SESSION:main.1" &
 echo $! > "$MONITOR_PID"
 
 # --- Focus lead pane ---
-tmux select-pane -t "$SESSION:main.0"
+$TMUX_CMD select-pane -t "$SESSION:main.0"
 
 # --- Attach ---
-tmux attach -t "$SESSION"
+$TMUX_CMD attach -t "$SESSION"

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SESSION="orca-$(basename "$(pwd)")"
+# Sanitize basename: tmux uses `.` and `:` as target separators
+# (session:window.pane), so dirs containing them break tmux targeting.
+SESSION="orca-$(basename "$(pwd)" | tr '.:' '--')"
 # Per-instance dedicated tmux server (D8): isolates orca from the user's main
 # tmux server so stop=kill-server gives a clean env on next start, and orca
 # never pollutes / inherits stale env from the user's long-lived server.

--- a/stop.sh
+++ b/stop.sh
@@ -11,16 +11,37 @@ SESSION="orca-$(basename "$(pwd)" | tr '.:' '--')"
 SOCKET="$SESSION"
 TMUX_CMD="tmux -L $SOCKET"
 
-if ! $TMUX_CMD has-session -t "$SESSION" 2>/dev/null; then
-  echo "Session '$SESSION' does not exist"
+# Detect both targets:
+#   - dedicated: session on per-instance server (D8, current scheme)
+#   - legacy:   session on user's main tmux server (pre-D8 orphans, since
+#               nothing else can manage them after the upgrade)
+HAS_DEDICATED=false
+HAS_LEGACY=false
+
+if $TMUX_CMD has-session -t "$SESSION" 2>/dev/null; then
+  HAS_DEDICATED=true
+fi
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  HAS_LEGACY=true
+fi
+
+if ! $HAS_DEDICATED && ! $HAS_LEGACY; then
+  echo "Session '$SESSION' does not exist (neither dedicated nor legacy)"
   exit 0
 fi
 
-echo "Panes in $SESSION:"
-$TMUX_CMD list-panes -t "$SESSION" -F "  #{pane_index}: #{pane_current_command} (pid: #{pane_pid})"
+echo "Found:"
+if $HAS_DEDICATED; then
+  echo "  - dedicated server: $SESSION"
+  $TMUX_CMD list-panes -t "$SESSION" -F "      pane #{pane_index}: #{pane_current_command} (pid: #{pane_pid})"
+fi
+if $HAS_LEGACY; then
+  echo "  - main tmux (legacy, pre-D8): $SESSION"
+  tmux list-panes -t "$SESSION" -F "      pane #{pane_index}: #{pane_current_command} (pid: #{pane_pid})"
+fi
 
 echo ""
-read -rp "Stop $SESSION? [y/N] " confirm
+read -rp "Stop all of the above? [y/N] " confirm
 if [[ "$confirm" != [yY] ]]; then
   echo "Cancelled"
   exit 0
@@ -32,7 +53,16 @@ if [ -f "$MONITOR_PID" ]; then
   rm -f "$MONITOR_PID"
 fi
 
-# Kill the dedicated server (not just the session). This is what gives the
-# next `orca` start a clean env — the server holds the cached -g environment.
-$TMUX_CMD kill-server 2>/dev/null || true
-echo "Stopped $SESSION (server killed, env cleared)"
+if $HAS_DEDICATED; then
+  # Kill the dedicated server (not just the session). This is what gives the
+  # next `orca` start a clean env — the server holds the cached -g environment.
+  $TMUX_CMD kill-server 2>/dev/null || true
+  echo "Stopped dedicated server for $SESSION (server killed, env cleared)"
+fi
+
+if $HAS_LEGACY; then
+  # Just kill the session, not the user's main tmux server (which may host
+  # other unrelated sessions).
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  echo "Cleaned up legacy $SESSION on main tmux server"
+fi

--- a/stop.sh
+++ b/stop.sh
@@ -2,14 +2,20 @@
 set -euo pipefail
 
 SESSION="orca-$(basename "$(pwd)")"
+# Per-instance dedicated tmux server (D8): the server only owns this one
+# session, so killing the server is equivalent to killing the session and
+# also wipes the cached global env that would otherwise leak into the next
+# `orca` start. See docs/troubleshooting/tmux-server-stale-env.md.
+SOCKET="$SESSION"
+TMUX_CMD="tmux -L $SOCKET"
 
-if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+if ! $TMUX_CMD has-session -t "$SESSION" 2>/dev/null; then
   echo "Session '$SESSION' does not exist"
   exit 0
 fi
 
 echo "Panes in $SESSION:"
-tmux list-panes -t "$SESSION" -F "  #{pane_index}: #{pane_current_command} (pid: #{pane_pid})"
+$TMUX_CMD list-panes -t "$SESSION" -F "  #{pane_index}: #{pane_current_command} (pid: #{pane_pid})"
 
 echo ""
 read -rp "Stop $SESSION? [y/N] " confirm
@@ -24,5 +30,7 @@ if [ -f "$MONITOR_PID" ]; then
   rm -f "$MONITOR_PID"
 fi
 
-tmux kill-session -t "$SESSION"
-echo "Stopped $SESSION"
+# Kill the dedicated server (not just the session). This is what gives the
+# next `orca` start a clean env — the server holds the cached -g environment.
+$TMUX_CMD kill-server 2>/dev/null || true
+echo "Stopped $SESSION (server killed, env cleared)"

--- a/stop.sh
+++ b/stop.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SESSION="orca-$(basename "$(pwd)")"
+# Sanitize basename: tmux uses `.` and `:` as target separators
+# (session:window.pane), so dirs containing them break tmux targeting.
+SESSION="orca-$(basename "$(pwd)" | tr '.:' '--')"
 # Per-instance dedicated tmux server (D8): the server only owns this one
 # session, so killing the server is equivalent to killing the session and
 # also wipes the cached global env that would otherwise leak into the next


### PR DESCRIPTION
## Summary

Implements **D8** (per-instance dedicated tmux server) plus a pre-existing fix and pre-D8 legacy cleanup, all surfaced during testing.

### Why

The user's main tmux server is long-lived and caches its global env at first-spawn time. Editing the shell profile and running `orca-stop` + `orca` did not pick up the new env, because stop only killed the session, not the server, and new sessions inherited the cached env.

### How

1. **`start.sh` / `stop.sh`** use `tmux -L orca-<dirname>` for an isolated per-instance server.
2. **`stop.sh`** does `kill-server` (safe — server only owns this one session). Next start forks a fresh server from the current shell, so env is always current.
3. **`tmux-bridge`** auto-detects the dedicated socket via `$TMUX` inside panes; for the out-of-pane `name` calls in `start.sh`, we pass the socket path explicitly via `TMUX_BRIDGE_SOCKET` (queried from tmux for portability across macOS `/private/tmp` and Linux `/tmp`).
4. **Pre-existing dot/colon bug** in basename sanitization — tmux uses `.` and `:` as target separators, so dirs like `/tmp/my.app` broke targeting. Replaced via `tr '.:' '--'`.
5. **Pre-D8 legacy cleanup** in `stop.sh` — sessions left on the user's main tmux server from before the upgrade are orphans (no orca code path can manage them). `stop.sh` now detects them alongside the dedicated session, lists both, and cleans both with a single confirmation.

### Commits

- `8d9884a` docs: plan per-instance tmux server isolation (D8) — PLAN.md D8 + P0 task list + troubleshooting doc
- `9ccf2b7` feat(orca): per-instance dedicated tmux server (D8) — start.sh + stop.sh implementation
- `0d41b90` fix(orca): sanitize dot and colon in dir basename for tmux session name — pre-existing bug surfaced during smoke test
- `df36e2b` feat(stop): also clean up pre-D8 legacy sessions on main tmux server

### Migration

None for state. Pre-D8 sessions on the user's main tmux are left alone until the user runs `orca-stop` in the same dir, at which point they are detected and cleaned up alongside the new dedicated session.

### Verification

End-to-end on real orca:
- start: dedicated server created, both panes labeled, env injected, claude + codex launched
- communication: `tmux-bridge read` / `message` / `keys` between lead and worker round-trip works
- stop: detected both dedicated (current run) and legacy (pre-upgrade) `orca-orca`, single y/N prompt, both killed; main tmux unrelated sessions intact; monitor PID file cleared; all 4 pane child processes gone

Smoke-tested in isolation:
- shell env propagation to pane via fresh server fork
- main tmux server isolation (orca session invisible to `tmux ls`)
- stale-env bug **reproduction** in cached server (proves the original problem)
- `kill-server` cleanup (server gone, env wiped)
- post-restart env refresh (new pane sees updated shell env)
- `tmux-bridge` `name` and `resolve` working on dedicated socket
- dot/colon sanitization (control: raw basename fails; sanitized: works end-to-end)
- legacy cleanup on synthetic dual-server scenario

## Test plan

- [x] `orca` in a fresh checkout creates a session on dedicated socket; main `tmux ls` does not show it
- [x] `orca-stop` kills the dedicated server; `tmux -L orca-<dir> ls` reports "no server running"
- [x] `orca-stop` also cleans up pre-D8 legacy session on main tmux without touching unrelated sessions
- [x] After `orca-stop && orca`, panes inherit the current shell's env
- [x] `tmux-bridge` lead/worker round-trip works on dedicated socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)
