### PR TITLE
refactor(install): fix /orca auto-trigger race + retire broken codex hook

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,7 +72,13 @@ if ! grep -q '.smux/bin' ~/.bash_profile 2>/dev/null && ! grep -q '.smux/bin' ~/
 fi
 
 # --- Make scripts executable ---
-chmod +x "$SCRIPT_DIR"/*.sh
+# Convention: `_*.sh` are sourced helper libraries (e.g. _lib.sh) and must
+# not be marked executable, otherwise `git status` stays dirty after every
+# install and the file could be invoked directly by mistake.
+for f in "$SCRIPT_DIR"/*.sh; do
+  [[ "$(basename "$f")" == _* ]] && continue
+  chmod +x "$f"
+done
 echo "[x] Script permissions set"
 
 # --- Create global command ---

--- a/install.sh
+++ b/install.sh
@@ -120,8 +120,13 @@ cat > "$CLAUDE_HOOK_TMP" << 'HOOKEOF'
 HOOKEOF
 
 CODEX_HOOK_TMP=$(mktemp)
+# Deprecated: Codex worker is activated by start.sh ($CODER_CMD '$orca' on
+# launch and the _skill_monitor banner-watcher after /clear). The hook payload
+# is reduced to a no-op shell `:`. We still register an entry — the $ORCA
+# signature lets install_or_update_hook recognise and overwrite legacy orca
+# hooks here on subsequent installs, instead of leaving them as orphans.
 cat > "$CODEX_HOOK_TMP" << 'HOOKEOF'
-[{"hooks":[{"type":"command","command":"[ -n \"$ORCA\" ] && echo 'Orca active. Role: worker. Run $orca'"}]}]
+[{"hooks":[{"type":"command","command":"[ -n \"$ORCA\" ] && :"}]}]
 HOOKEOF
 
 # install_or_update_hook <settings-file> <hook-tmp> <label>

--- a/install.sh
+++ b/install.sh
@@ -114,13 +114,14 @@ CLAUDE_HOOK_TMP=$(mktemp)
 # typed anything (trailing non-whitespace breaks the match) or is stuck on
 # a modal like the trust dialog (`❯ 1. Yes, I trust this folder` has
 # non-whitespace after the cursor, so it does not falsely trigger). Max
-# poll budget is 30s to cover slow trust-dialog dismissal.
+# poll budget is 60s to absorb cold-start jitter and slow trust-dialog
+# dismissal on the first orca-in-this-dir launch.
 # Why `Enter` (not `C-m`): with tmux extended-keys on, CC negotiates the Kitty
 # keyboard protocol and expects the extended Enter sequence. `C-m` sends raw \r
 # which is then treated as literal text. `Enter` (named key) lets tmux emit
 # whatever the inner program negotiated.
 cat > "$CLAUDE_HOOK_TMP" << 'HOOKEOF'
-[{"hooks":[{"type":"command","command":"[ -n \"$ORCA\" ] && nohup bash -c 'for i in $(seq 1 100); do sleep 0.3; tmux capture-pane -p -t \"$TMUX_PANE\" 2>/dev/null | tail -5 | grep -qE \"^[[:space:]]*(>|❯|›)[[:space:]]*\\$\" && { tmux send-keys -l -t \"$TMUX_PANE\" /orca; sleep 0.2; tmux send-keys -t \"$TMUX_PANE\" Enter; exit 0; }; done' >/dev/null 2>&1 &"}]}]
+[{"hooks":[{"type":"command","command":"[ -n \"$ORCA\" ] && nohup bash -c 'for i in $(seq 1 200); do sleep 0.3; tmux capture-pane -p -t \"$TMUX_PANE\" 2>/dev/null | grep -qE \"^[[:space:]]*(>|❯|›)[[:space:]]*\\$\" && { tmux send-keys -l -t \"$TMUX_PANE\" /orca; sleep 0.2; tmux send-keys -t \"$TMUX_PANE\" Enter; exit 0; }; done' >/dev/null 2>&1 &"}]}]
 HOOKEOF
 
 CODEX_HOOK_TMP=$(mktemp)

--- a/install.sh
+++ b/install.sh
@@ -124,16 +124,6 @@ cat > "$CLAUDE_HOOK_TMP" << 'HOOKEOF'
 [{"hooks":[{"type":"command","command":"[ -n \"$ORCA\" ] && nohup bash -c 'for i in $(seq 1 200); do sleep 0.3; tmux capture-pane -p -t \"$TMUX_PANE\" 2>/dev/null | grep -qE \"^[[:space:]]*(>|❯|›)[[:space:]]*\\$\" && { tmux send-keys -l -t \"$TMUX_PANE\" /orca; sleep 0.2; tmux send-keys -t \"$TMUX_PANE\" Enter; exit 0; }; done' >/dev/null 2>&1 &"}]}]
 HOOKEOF
 
-CODEX_HOOK_TMP=$(mktemp)
-# Deprecated: Codex worker is activated by start.sh ($CODER_CMD '$orca' on
-# launch and the _skill_monitor banner-watcher after /clear). The hook payload
-# is reduced to a no-op shell `:`. We still register an entry — the $ORCA
-# signature lets install_or_update_hook recognise and overwrite legacy orca
-# hooks here on subsequent installs, instead of leaving them as orphans.
-cat > "$CODEX_HOOK_TMP" << 'HOOKEOF'
-[{"hooks":[{"type":"command","command":"[ -n \"$ORCA\" ] && :"}]}]
-HOOKEOF
-
 # install_or_update_hook <settings-file> <hook-tmp> <label>
 # Scoped to orca-managed entries only: drops any existing SessionStart entry
 # whose command contains the "$ORCA" signature, then appends the new orca
@@ -153,14 +143,39 @@ install_or_update_hook() {
   echo "[x] $label SessionStart hook installed (orca-managed)"
 }
 
+# cleanup_orca_hook <settings-file> <label>
+# Removes any SessionStart entries carrying the $ORCA signature, then collapses
+# the surrounding scaffolding: empty SessionStart array → drop the key; empty
+# hooks object → drop the key; resulting empty file → delete it. Leaves
+# unrelated entries / top-level keys untouched.
+cleanup_orca_hook() {
+  local settings="$1" label="$2"
+  [ -f "$settings" ] || return 0
+  jq -e '.hooks.SessionStart' "$settings" >/dev/null 2>&1 || return 0
+  jq '
+    .hooks.SessionStart |= map(select(.hooks | tostring | test("\\$ORCA") | not)) |
+    if (.hooks.SessionStart | length) == 0 then del(.hooks.SessionStart) else . end |
+    if (.hooks // {} | length) == 0 then del(.hooks) else . end
+  ' "$settings" > "$settings.tmp" && mv "$settings.tmp" "$settings"
+  if [ "$(jq -c '.' "$settings")" = "{}" ]; then
+    rm -f "$settings"
+    echo "[x] $label hooks file removed (orca was the only entry)"
+  else
+    echo "[x] $label SessionStart orca-managed entries removed"
+  fi
+}
+
 # Claude Code hook
 install_or_update_hook ~/.claude/settings.json "$CLAUDE_HOOK_TMP" "Claude Code"
 
-# Codex hook
-mkdir -p ~/.codex
-install_or_update_hook ~/.codex/hooks.json "$CODEX_HOOK_TMP" "Codex"
+# Codex worker activation is fully owned by start.sh ($CODER_CMD '$orca' on
+# launch + _skill_monitor banner-watcher after /clear), so codex needs no
+# SessionStart hook from us. Strip any legacy orca-managed entry from prior
+# installs so codex's hook runner doesn't choke on a stale `[ -n "$ORCA" ]`
+# command (which exits 1 outside an orca pane and breaks codex sessions).
+cleanup_orca_hook ~/.codex/hooks.json "Codex"
 
-rm -f "$CLAUDE_HOOK_TMP" "$CODEX_HOOK_TMP"
+rm -f "$CLAUDE_HOOK_TMP"
 
 echo ""
 echo "=== Install complete ==="

--- a/install.sh
+++ b/install.sh
@@ -120,32 +120,22 @@ cat > "$CODEX_HOOK_TMP" << 'HOOKEOF'
 HOOKEOF
 
 # install_or_update_hook <settings-file> <hook-tmp> <label>
-# - File missing: create with our hook
-# - SessionStart absent: add ours alongside whatever else is in the file
-# - SessionStart present and contains "$ORCA" signature: orca-managed, replace
-#   so re-running install.sh upgrades legacy installs
-# - SessionStart present without our signature: foreign hook, skip and warn
+# Scoped to orca-managed entries only: drops any existing SessionStart entry
+# whose command contains the "$ORCA" signature, then appends the new orca
+# entry. Foreign (non-orca) entries are preserved untouched. Re-running
+# install.sh therefore both upgrades legacy orca hooks and leaves coexisting
+# tools alone.
 install_or_update_hook() {
   local settings="$1" hook_tmp="$2" label="$3"
-  if [ ! -f "$settings" ]; then
-    echo '{}' | jq --slurpfile hook "$hook_tmp" '{hooks: {SessionStart: $hook[0]}}' > "$settings"
-    echo "[x] $label SessionStart hook created"
-    return
-  fi
-  if ! jq -e '.hooks.SessionStart' "$settings" &>/dev/null; then
-    jq --slurpfile hook "$hook_tmp" '.hooks = (.hooks // {}) + {SessionStart: $hook[0]}' \
-      "$settings" > "$settings.tmp" && mv "$settings.tmp" "$settings"
-    echo "[x] $label SessionStart hook registered"
-    return
-  fi
-  if jq -e '.hooks.SessionStart | tostring | test("\\$ORCA")' "$settings" &>/dev/null; then
-    jq --slurpfile hook "$hook_tmp" '.hooks.SessionStart = $hook[0]' \
-      "$settings" > "$settings.tmp" && mv "$settings.tmp" "$settings"
-    echo "[x] $label SessionStart hook updated (orca-managed)"
-  else
-    echo "[!] $label SessionStart hook exists and is not orca-managed, skipping"
-    echo "    Manually merge orca's hook from install.sh if needed"
-  fi
+  [ -f "$settings" ] || echo '{}' > "$settings"
+  jq --slurpfile hook "$hook_tmp" '
+    .hooks //= {} |
+    .hooks.SessionStart = (
+      ((.hooks.SessionStart // []) | map(select(.hooks | tostring | test("\\$ORCA") | not)))
+      + $hook[0]
+    )
+  ' "$settings" > "$settings.tmp" && mv "$settings.tmp" "$settings"
+  echo "[x] $label SessionStart hook installed (orca-managed)"
 }
 
 # Claude Code hook

--- a/install.sh
+++ b/install.sh
@@ -108,15 +108,19 @@ CLAUDE_HOOK_TMP=$(mktemp)
 # We have to type /orca into the input box and submit it.
 # Why poll (not a fixed `sleep N`): a fixed delay either fires before CC is
 # ready (the typed /orca becomes literal text) or fires while the user is
-# already typing manually (race-condition garble). Polling for the prompt
-# indicator (>|❯|›) fires as soon as CC accepts input — usually <1s — so the
-# typing-conflict window stays small in practice.
+# already typing manually (race-condition garble). Polling for an empty
+# prompt line (`^[[:space:]]*(>|❯|›)[[:space:]]*$`) fires as soon as CC
+# accepts input — usually <1s — and naturally aborts when the user has
+# typed anything (trailing non-whitespace breaks the match) or is stuck on
+# a modal like the trust dialog (`❯ 1. Yes, I trust this folder` has
+# non-whitespace after the cursor, so it does not falsely trigger). Max
+# poll budget is 30s to cover slow trust-dialog dismissal.
 # Why `Enter` (not `C-m`): with tmux extended-keys on, CC negotiates the Kitty
 # keyboard protocol and expects the extended Enter sequence. `C-m` sends raw \r
 # which is then treated as literal text. `Enter` (named key) lets tmux emit
 # whatever the inner program negotiated.
 cat > "$CLAUDE_HOOK_TMP" << 'HOOKEOF'
-[{"hooks":[{"type":"command","command":"[ -n \"$ORCA\" ] && nohup bash -c 'for i in $(seq 1 40); do sleep 0.3; tmux capture-pane -p -t \"$TMUX_PANE\" 2>/dev/null | tail -5 | grep -qE \"^[[:space:]]*(>|❯|›)[[:space:]]\" && { tmux send-keys -l -t \"$TMUX_PANE\" /orca; sleep 0.2; tmux send-keys -t \"$TMUX_PANE\" Enter; exit 0; }; done' >/dev/null 2>&1 &"}]}]
+[{"hooks":[{"type":"command","command":"[ -n \"$ORCA\" ] && nohup bash -c 'for i in $(seq 1 100); do sleep 0.3; tmux capture-pane -p -t \"$TMUX_PANE\" 2>/dev/null | tail -5 | grep -qE \"^[[:space:]]*(>|❯|›)[[:space:]]*\\$\" && { tmux send-keys -l -t \"$TMUX_PANE\" /orca; sleep 0.2; tmux send-keys -t \"$TMUX_PANE\" Enter; exit 0; }; done' >/dev/null 2>&1 &"}]}]
 HOOKEOF
 
 CODEX_HOOK_TMP=$(mktemp)

--- a/install.sh
+++ b/install.sh
@@ -106,12 +106,17 @@ CLAUDE_HOOK_TMP=$(mktemp)
 # Why elaborate (not a plain echo of an instruction): in practice CC does NOT
 # reliably auto-invoke the orca skill from a SessionStart system message.
 # We have to type /orca into the input box and submit it.
+# Why poll (not a fixed `sleep N`): a fixed delay either fires before CC is
+# ready (the typed /orca becomes literal text) or fires while the user is
+# already typing manually (race-condition garble). Polling for the prompt
+# indicator (>|❯|›) fires as soon as CC accepts input — usually <1s — so the
+# typing-conflict window stays small in practice.
 # Why `Enter` (not `C-m`): with tmux extended-keys on, CC negotiates the Kitty
 # keyboard protocol and expects the extended Enter sequence. `C-m` sends raw \r
 # which is then treated as literal text. `Enter` (named key) lets tmux emit
 # whatever the inner program negotiated.
 cat > "$CLAUDE_HOOK_TMP" << 'HOOKEOF'
-[{"hooks":[{"type":"command","command":"[ -n \"$ORCA\" ] && nohup bash -c 'sleep 5; tmux send-keys -l -t \"$TMUX_PANE\" /orca; sleep 0.5; tmux send-keys -t \"$TMUX_PANE\" Enter' >/dev/null 2>&1 &"}]}]
+[{"hooks":[{"type":"command","command":"[ -n \"$ORCA\" ] && nohup bash -c 'for i in $(seq 1 40); do sleep 0.3; tmux capture-pane -p -t \"$TMUX_PANE\" 2>/dev/null | tail -5 | grep -qE \"^[[:space:]]*(>|❯|›)[[:space:]]\" && { tmux send-keys -l -t \"$TMUX_PANE\" /orca; sleep 0.2; tmux send-keys -t \"$TMUX_PANE\" Enter; exit 0; }; done' >/dev/null 2>&1 &"}]}]
 HOOKEOF
 
 CODEX_HOOK_TMP=$(mktemp)

--- a/install.sh
+++ b/install.sh
@@ -133,13 +133,21 @@ HOOKEOF
 install_or_update_hook() {
   local settings="$1" hook_tmp="$2" label="$3"
   [ -f "$settings" ] || echo '{}' > "$settings"
-  jq --slurpfile hook "$hook_tmp" '
+  # Two-step write so a jq failure does not leave the success message lying.
+  # `set -e` does not catch failures inside `cmd && cmd` (checked context),
+  # so we test jq explicitly and surface the error.
+  if ! jq --slurpfile hook "$hook_tmp" '
     .hooks //= {} |
     .hooks.SessionStart = (
       ((.hooks.SessionStart // []) | map(select(.hooks | tostring | test("\\$ORCA") | not)))
       + $hook[0]
     )
-  ' "$settings" > "$settings.tmp" && mv "$settings.tmp" "$settings"
+  ' "$settings" > "$settings.tmp"; then
+    rm -f "$settings.tmp"
+    echo "[!] $label SessionStart hook install failed (jq error)" >&2
+    return 1
+  fi
+  mv "$settings.tmp" "$settings"
   echo "[x] $label SessionStart hook installed (orca-managed)"
 }
 
@@ -152,11 +160,16 @@ cleanup_orca_hook() {
   local settings="$1" label="$2"
   [ -f "$settings" ] || return 0
   jq -e '.hooks.SessionStart' "$settings" >/dev/null 2>&1 || return 0
-  jq '
+  if ! jq '
     .hooks.SessionStart |= map(select(.hooks | tostring | test("\\$ORCA") | not)) |
     if (.hooks.SessionStart | length) == 0 then del(.hooks.SessionStart) else . end |
     if (.hooks // {} | length) == 0 then del(.hooks) else . end
-  ' "$settings" > "$settings.tmp" && mv "$settings.tmp" "$settings"
+  ' "$settings" > "$settings.tmp"; then
+    rm -f "$settings.tmp"
+    echo "[!] $label hooks cleanup failed (jq error)" >&2
+    return 1
+  fi
+  mv "$settings.tmp" "$settings"
   if [ "$(jq -c '.' "$settings")" = "{}" ]; then
     rm -f "$settings"
     echo "[x] $label hooks file removed (orca was the only entry)"

--- a/skills/orca/SKILL.md
+++ b/skills/orca/SKILL.md
@@ -32,7 +32,7 @@ Read Guard: must `read` before every `type`/`keys`.
 
 ## Worker
 
-1. **Wait** — reply "Worker ready." and end turn
+1. **Wait** — reply "Worker ready." in own pane (do not message lead) and end turn
 2. **Implement** → **Self-review** (/review, fix, repeat) → **Test** (build + tests)
 3. **Report** — 1-2 sentence summary, no code/diffs
 


### PR DESCRIPTION
## Summary

- `/orca` auto-trigger no longer waits a fixed 5s nor garbles user typing: the `SessionStart` hook now polls every 0.3s for an empty prompt line (max 60s budget) instead of `sleep 5; send /orca`. When the user has already started typing, the prompt line carries non-whitespace and the poll naturally aborts. The first-launch trust dialog (`❯ 1. Yes, I trust this folder`) also fails the empty-line check, so it no longer steals the trigger.
- `~/.codex/hooks.json` is now removed entirely (not replaced with a no-op). Codex treats any non-zero `SessionStart` exit as fatal, and the previous `[ -n "$ORCA" ] && :` placeholder exited 1 in any non-orca codex session — even the desktop app started failing with `hook exited with code 1`. Worker activation is fully owned by `start.sh`, so the hook never had a job to do.
- `install.sh` jq writes are now `if jq ...; then mv; else warn; return 1`. Previously `cmd && cmd` swallowed jq failures because `set -e` does not trigger inside checked contexts.
- `install_or_update_hook` is scoped to entries carrying the `$ORCA` signature, preserving any coexisting non-orca `SessionStart` hooks and unrelated top-level keys.
- Drive-by: `chmod +x *.sh` no longer marks sourced helpers (`_lib.sh`) executable. Internal/sourced files follow a `_*.sh` naming convention and are skipped, so `git status` stays clean after install.
- `SKILL.md` worker step 1 now says `reply "Worker ready." in own pane (do not message lead)` to remove the ambiguity that pushed the worker to bridge the message back to lead.

## Test plan

Verified locally:
- [x] Decoded hook command passes `bash -n`
- [x] Hook exits 0 with or without `$ORCA` set (the trailing `&` backgrounds the whole `[ -n "$ORCA" ] && nohup ...` expression, so claude always sees 0 — won't repeat the codex breakage)
- [x] Regex matches a real empty prompt, rejects the trust dialog `❯ 1. Yes...`, rejects user-typed `❯ hello`
- [x] `tmux capture-pane -p` strips ANSI by default; the regex sees clean text
- [x] Install behavior matrix (5 cases): empty file / unrelated top-level keys / foreign `SessionStart` entry / stale orca + foreign coexisting / multi-event hooks — all preserve non-orca content
- [x] Cleanup deletes the file when orca was the only entry
- [x] `install.sh` is idempotent across re-runs
- [x] On jq failure: no stale `.tmp`, original file untouched, error on stderr, exit 1
- [x] `chmod` no longer touches `_lib.sh`; `git status` is clean after install
- [x] End-to-end: fresh `/tmp` dir with trust dialog → dismiss → `/orca` correctly injected into the real empty prompt ~2s later

Still to validate in real use:
- [x] Reopen the codex desktop app and confirm `hook exited with code 1` is gone
- [ ] A week of daily use to confirm the claude-launch → `/orca` trigger latency feels right
