### PR TITLE
feat(start): pass through OSC 8 hyperlinks for Cmd+Click in tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Talk to the lead (left pane): `Have the coder write a hello world script`
 
 - **Codex macOS sandbox**: openai/codex#10390 — using `--sandbox danger-full-access -a on-request`
 - **Shift+Enter in Codex (Ghostty + tmux)**: Codex 0.121 doesn't negotiate the Kitty keyboard protocol under tmux, so Ghostty's Shift+Enter doesn't reach it. Use Option+Enter for newline, or remap Shift+Enter in Ghostty config — see [docs/troubleshooting/ghostty-codex-shift-enter.md](docs/troubleshooting/ghostty-codex-shift-enter.md).
+- **Cmd+Click links in Ghostty + tmux**: tmux `mouse on` consumes Cmd+Click before Ghostty can turn it into a hyperlink jump. Use **Shift+Cmd+Click** instead, or switch to Zed/iTerm2/WezTerm — see [docs/troubleshooting/tmux-osc8-hyperlinks.md](docs/troubleshooting/tmux-osc8-hyperlinks.md).
 - **Single worker**: Multi-worker planned (see [PLAN.md](PLAN.md))
 
 ## License

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,6 +46,7 @@ orca-stop               # 停止
 
 - **Codex macOS 沙箱**：openai/codex#10390 — 使用 `--sandbox danger-full-access -a on-request`
 - **Codex 内 Shift+Enter（Ghostty + tmux）**：Codex 0.121 在 tmux 下不协商 Kitty 键盘协议，Ghostty 的 Shift+Enter 编码到不了它。换行用 Option+Enter，或在 Ghostty config 里 remap Shift+Enter — 见 [docs/troubleshooting/ghostty-codex-shift-enter.md](docs/troubleshooting/ghostty-codex-shift-enter.md)。
+- **Ghostty + tmux 内 Cmd+Click 跳转链接**：tmux `mouse on` 在 Ghostty 转成 hyperlink 跳转之前就消费了 Cmd+Click。改用 **Shift+Cmd+Click**，或换 Zed/iTerm2/WezTerm — 见 [docs/troubleshooting/tmux-osc8-hyperlinks.md](docs/troubleshooting/tmux-osc8-hyperlinks.md)。
 - **单 worker**：多 worker 计划中（见 [PLAN.md](PLAN.md)）
 
 ## License

--- a/docs/troubleshooting/tmux-osc8-hyperlinks.md
+++ b/docs/troubleshooting/tmux-osc8-hyperlinks.md
@@ -1,0 +1,87 @@
+# OSC 8 hyperlinks (Cmd+Click links) inside tmux
+
+## Symptom
+
+In a terminal that supports OSC 8 hyperlinks, link text emitted by inner
+CLIs (e.g. Claude Code rendering markdown links like
+`[Anthropic](https://www.anthropic.com)`) shows the styled text but
+**Cmd+Click does not jump** while the CLI runs inside an orca tmux
+session. The same CLI run directly in the terminal (no tmux) jumps fine.
+
+## Reproduction matrix
+
+| Terminal       | tmux | Click modifier      | Result        |
+|----------------|------|---------------------|---------------|
+| Ghostty 1.3.x  | no   | Cmd+Click           | works         |
+| Ghostty 1.3.x  | yes  | Cmd+Click           | **broken**    |
+| Ghostty 1.3.x  | yes  | Shift+Cmd+Click     | works         |
+| Zed terminal   | yes  | Cmd+Click           | works         |
+| iTerm2 / WezTerm | yes | Cmd+Click          | expected to work (not yet measured) |
+
+Tested on tmux 3.6a with this repo's `start.sh` configuration.
+
+## Root cause
+
+Two separate mechanisms stack on top of each other:
+
+1. **OSC 8 transport** — tmux strips the OSC 8 escape sequence from inner
+   programs unless `terminal-features` advertises `:hyperlinks`. Without
+   it, the outer terminal only receives plain styled text and has no URL
+   to jump to. `start.sh` sets this feature for every orca session, so
+   transport is in place — verified with
+   `tmux show-options -gs terminal-features` listing `*:hyperlinks`.
+
+2. **Mouse capture** — `start.sh` sets `mouse on` so users can drag pane
+   borders and scroll the scrollback. With mouse mode active, tmux
+   consumes mouse events inside panes and the outer terminal never sees
+   the click. Most macOS terminals (iTerm2, WezTerm, Zed) special-case
+   the Cmd modifier and forward Cmd+Click to themselves regardless of
+   tmux mouse mode. Ghostty does not — by default it requires the
+   **Shift** modifier to bypass tmux mouse capture
+   (`mouse-shift-capture = true`).
+
+So in Ghostty + tmux + `mouse on`, plain Cmd+Click never reaches Ghostty
+to be turned into a hyperlink jump. Shift+Cmd+Click does.
+
+## Workarounds
+
+### Option A — Use Shift+Cmd+Click (recommended for Ghostty users)
+
+No configuration change. Hold Shift while Cmd+Clicking. This is the
+standard Ghostty + tmux interaction for any mouse action that needs to
+bypass tmux mouse capture (text selection works the same way).
+
+### Option B — Disable Ghostty's mouse-shift-capture
+
+Set in `~/Library/Application Support/com.mitchellh.ghostty/config.ghostty`
+(macOS) or `~/.config/ghostty/config` (Linux):
+
+```
+mouse-shift-capture = false
+```
+
+Lets plain Cmd+Click reach Ghostty. Trade-off: Shift no longer bypasses
+tmux mouse for *any* action, so selecting text with the mouse becomes
+awkward (you'd have to hold Option for tmux's own copy mode, etc.).
+
+### Option C — Switch terminal
+
+Zed's built-in terminal handles Cmd+Click correctly inside tmux without
+any extra config. iTerm2 and WezTerm follow the same convention.
+
+## Why this isn't fixed in orca
+
+Disabling `mouse on` in tmux would fix Cmd+Click for Ghostty but break
+pane-border dragging and scrollback scrolling for everyone — a worse
+trade than asking Ghostty users to add a Shift.
+
+The `terminal-features ',*:hyperlinks'` line in `start.sh` is still
+necessary regardless: it's what makes the URL information reach the
+outer terminal in the first place. Without it, even Zed's Cmd+Click
+would have nothing to jump to.
+
+## Removal criteria
+
+This page can be retired when Ghostty changes its default to forward
+Cmd+Click to itself instead of letting tmux capture it. Track:
+[ghostty#11907](https://github.com/ghostty-org/ghostty/issues/11907).

--- a/start.sh
+++ b/start.sh
@@ -87,6 +87,12 @@ $TMUX_CMD set-option -gs extended-keys on
 if ! $TMUX_CMD show-options -gs terminal-features 2>/dev/null | grep -q ':extkeys'; then
   $TMUX_CMD set-option -ga terminal-features ',*:extkeys'
 fi
+# Pass through OSC 8 hyperlinks so terminals (Ghostty/Zed/iTerm2) can cmd+click
+# link text emitted by inner CLIs (e.g. Claude Code). Without this tmux strips
+# the escape sequence and only the plain text reaches the outer terminal.
+if ! $TMUX_CMD show-options -gs terminal-features 2>/dev/null | grep -q ':hyperlinks'; then
+  $TMUX_CMD set-option -ga terminal-features ',*:hyperlinks'
+fi
 
 # --- Name panes (session-prefixed for multi-instance isolation) ---
 LEAD_LABEL="${SESSION}-lead"


### PR DESCRIPTION
## Summary

- Add `terminal-features ',*:hyperlinks'` to the orca tmux server so OSC 8 escape sequences from inner CLIs (e.g. Claude Code markdown links like `[Anthropic](https://www.anthropic.com)`) reach the outer terminal. Without this, tmux strips the sequence and only plain styled text reaches the terminal — leaving nothing to jump to on Cmd+Click.
- Document the Ghostty-specific gotcha: tmux `mouse on` consumes plain Cmd+Click before Ghostty can turn it into a hyperlink jump. **Shift+Cmd+Click** works (standard Ghostty + tmux convention). Most other terminals (Zed, iTerm2, WezTerm) special-case Cmd and don't have this problem.

## Stack

Based on `refactor/orca-hooks` (PR #6) — touches the same `start.sh` region PR #4 modified (`tmux` → `\$TMUX_CMD` rename), so stacking avoids a rebase conflict.

## Test plan

- [x] `tmux show-options -gs terminal-features` lists `*:hyperlinks` after `./stop.sh && ./start.sh`
- [x] **Zed terminal**: Cmd+Click on Claude Code's markdown link jumps correctly inside tmux
- [x] **Ghostty**: Shift+Cmd+Click jumps; plain Cmd+Click intentionally consumed by tmux mouse (documented)
- [x] Idempotent guard prevents duplicate `:hyperlinks` entries on repeated `start.sh` runs

## Docs

- New: \`docs/troubleshooting/tmux-osc8-hyperlinks.md\` (reproduction matrix, root cause, three workarounds, removal criteria)
- Both READMEs: added Known Limitations entry pointing at the troubleshooting doc

## References

- [ghostty#11907](https://github.com/ghostty-org/ghostty/issues/11907) — tracking issue for Ghostty Cmd+Click in tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)