### PR TITLE
feat: P0 multi-worker + worktree + heartbeat + code workflow

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -53,19 +53,20 @@ orca --lead claude --worker codex --workers 3 --workflow code
 ## P0: Multi-Worker + Isolation + Hooks
 
 **start.sh**
-- [ ] `--workers N` — max workers (default 1), lead creates panes on demand
-- [ ] `--lead <model>` / `--worker <model>` — model selection (D9: requires hook + SKILL.md role-detection rework)
-- [ ] `--workflow <name>` — load workflow skill
+- [x] `--workers N` — max workers (default 1), multi-pane creation
+- [x] `--lead <model>` / `--worker <model>` — model selection (resolves D9: role from `$ORCA_ROLE` env var)
+- [x] `--workflow <name>` — load workflow skill
 
 **Worktree**
-- [ ] On-demand `<repo>/.orca/worktree/<id>` at dispatch (D5)
-- [ ] `orca-worktree create/remove` helper
-- [ ] stop.sh cleanup
+- [x] On-demand `<repo>/.orca/worktree/<id>` at dispatch (D5)
+- [x] `orca-worktree create/remove/list/clean` helper
+- [x] stop.sh cleanup
 
 **Hooks** (D1, D3)
-- [ ] `hooks/post-tool-use.sh` — heartbeat + idle detection + tmux-bridge notify
-- [ ] Auto-generate `.codex/hooks.json` (Codex) / CC hooks per worker
-- [ ] `.orca/heartbeat/` — cooldown: 30s per-worker, 60s all-idle
+- [x] `hooks/post-tool-use.sh` — worker heartbeat (PostToolUse)
+- [x] `hooks/check-heartbeat.sh` — lead idle check (PreToolUse)
+- [x] install.sh registers PostToolUse/PreToolUse hooks for CC
+- [x] `.orca/heartbeat/` — 30s per-worker cooldown
 
 **Multi-instance per dir** (D7, design TBD)
 - [ ] Re-running `orca` in a dir with existing session(s): prompt to attach existing or start new (Claude Code resume-style)
@@ -87,7 +88,7 @@ Light core skill + moderate workflow skills (D4).
 
 ```
 skills/orca/SKILL.md              # core (current)
-skills/workflows/code/SKILL.md    # dispatch → parallel code → merge → optimize
+skills/workflows/code/SKILL.md    # dispatch → parallel code → merge → optimize  ✅
 skills/workflows/review/SKILL.md  # dispatch → parallel review → aggregate
 skills/workflows/explore/SKILL.md # dispatch → parallel research → synthesize
 skills/workflows/refactor/SKILL.md # dispatch → parallel refactor → sequential merge

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,13 @@
 
 **2 agents over 3** — Reviewer removed. Codex `/review` + Claude `/simplify` covers it. Cross-model review is more valuable than same-model independent reviewer.
 
-**Shared skill** — one `skills/orca/SKILL.md` for both roles. Role by activation command (`/orca` = lead, `$orca` = worker). Dynamic peer via `$ORCA_PEER`.
+**Shared skill** — one `skills/orca/SKILL.md` for both roles. Role from `$ORCA_ROLE` env var (not activation command). Lead gets `$ORCA_WORKERS` (CSV), workers get `$ORCA_PEER` pointing to lead.
+
+**Heartbeat via hooks** — no background monitor (deferred to P3). Workers write timestamps via PostToolUse hook (`.orca/heartbeat/<id>`). Lead checks heartbeats via PreToolUse hook, outputs `[orca]` notifications inline on next tool use. 30s cooldown per worker. Limitation: notifications only surface when lead is actively using tools.
+
+**On-demand worktrees** — `orca-worktree create/remove/list/clean` at `.orca/worktree/<id>`. Created by lead before dispatch, cleaned by `orca stop`.
+
+**Handoff files** — long-context dispatch uses `/tmp/orca-handoff-<slug>-<timestamp>.md` instead of inline tmux-bridge messages. Survives truncation, context compaction, and worker restarts.
 
 **Codex sandbox** — macOS Seatbelt `network_access=true` broken for AF_UNIX (openai/codex#10390). Using `--sandbox danger-full-access -a on-request`. Waiting for fix.
 
@@ -20,11 +26,10 @@
 
 | Path | Action |
 |------|--------|
-| `~/.local/bin/orca` | symlink (subcommands `stop`/`idle`/`ps`/`rm`/`prune` dispatched inside) |
-| `~/.claude/skills/orca` | symlink |
-| `~/.agents/skills/orca` | symlink |
-| `~/.claude/settings.json` | append SessionStart hook |
-| `~/.codex/hooks.json` | create/append SessionStart hook |
+| `~/.local/bin/orca, orca-worktree` | symlinks |
+| `~/.claude/skills/orca, orca-code` | symlinks |
+| `~/.agents/skills/orca, orca-code` | symlinks |
+| `~/.claude/settings.json` | SessionStart + PostToolUse + PreToolUse hooks |
 | `~/.smux/bin/` | install smux binary |
 
 start.sh also sets per-session: `mode-keys vi`, `mouse on`, `bind-key Space even-horizontal`.

--- a/docs/superpowers/plans/2026-04-17-p0-multi-worker.md
+++ b/docs/superpowers/plans/2026-04-17-p0-multi-worker.md
@@ -1,0 +1,661 @@
+# P0: Multi-Worker + Isolation + Hooks
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Multi-worker orchestration with worktree isolation and heartbeat-based idle detection.
+
+**Architecture:** start.sh gains `--workers/--lead/--worker/--workflow` flags, creates N worker panes. Workers get isolated git worktrees on demand. PostToolUse hooks write heartbeat timestamps; lead's PreToolUse hook checks heartbeats and surfaces idle notifications. Role determined by `$ORCA_ROLE` env var (not activation command).
+
+**Tech Stack:** bash, tmux, tmux-bridge (smux), git worktree
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `start.sh` | CLI args, model mapping, multi-worker pane creation, monitors |
+| Modify | `stop.sh` | Worktree cleanup, multi-monitor PID cleanup |
+| Modify | `install.sh` | Register orca-worktree command, PostToolUse/PreToolUse hooks |
+| Modify | `skills/orca/SKILL.md` | Role from `$ORCA_ROLE`, multi-worker dispatch, heartbeat |
+| Create | `orca-worktree.sh` | git worktree create/remove/list/clean |
+| Create | `hooks/post-tool-use.sh` | Worker heartbeat: write timestamp |
+| Create | `hooks/check-heartbeat.sh` | Lead notification: check idle workers |
+
+---
+
+### Task 1: start.sh — CLI args + model mapping + multi-worker
+
+**Files:**
+- Modify: `start.sh`
+
+- [ ] **Step 1: Rewrite start.sh with CLI arg parsing and multi-worker support**
+
+Replace entire start.sh:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Defaults ---
+WORKERS=1
+LEAD_MODEL="claude"
+WORKER_MODEL="codex"
+WORKFLOW=""
+
+# --- Usage ---
+usage() {
+  cat <<EOF
+Usage: orca [OPTIONS]
+
+Options:
+  --workers N, -n N    Number of workers (default: 1)
+  --lead MODEL         Lead model (default: claude)
+  --worker MODEL       Worker model (default: codex)
+  --workflow NAME, -w  Workflow skill to load
+  -h, --help           Show this help
+EOF
+}
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workers|-n) WORKERS="$2"; shift 2 ;;
+    --lead)       LEAD_MODEL="$2"; shift 2 ;;
+    --worker)     WORKER_MODEL="$2"; shift 2 ;;
+    --workflow|-w) WORKFLOW="$2"; shift 2 ;;
+    -h|--help)    usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+SESSION="orca-$(basename "$(pwd)")"
+
+# --- Model command mapping ---
+model_cmd() {
+  case "$1" in
+    claude) echo "claude" ;;
+    codex)  echo "codex --sandbox danger-full-access -a on-request -c features.codex_hooks=true" ;;
+    *)      echo "$1" ;;
+  esac
+}
+
+# --- Launch agent in pane ---
+launch_agent() {
+  local pane="$1" model="$2" role="$3"
+  local cmd
+  cmd=$(model_cmd "$model")
+  case "$model" in
+    codex)
+      local skill_cmd="\$orca"
+      [[ "$role" == "lead" ]] && skill_cmd="/orca"
+      tmux send-keys -t "$pane" "$cmd '$skill_cmd'" Enter
+      ;;
+    *)
+      tmux send-keys -t "$pane" "$cmd" Enter
+      ;;
+  esac
+}
+
+# --- Prerequisites ---
+for bin in tmux tmux-bridge; do
+  if ! command -v "$bin" &>/dev/null; then
+    echo "Error: $bin not installed" >&2
+    exit 1
+  fi
+done
+
+check_model() {
+  local bin
+  bin=$(model_cmd "$1" | awk '{print $1}')
+  if ! command -v "$bin" &>/dev/null; then
+    echo "Error: $bin not installed" >&2
+    exit 1
+  fi
+}
+check_model "$LEAD_MODEL"
+check_model "$WORKER_MODEL"
+
+# --- Reattach if exists ---
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  tmux attach -t "$SESSION"
+  exit 0
+fi
+
+# --- Working directory ---
+WORKDIR="${ORCA_WORKDIR:-$(pwd)}"
+
+# --- Info ---
+echo "Starting $SESSION ..."
+echo "  Lead:     $(model_cmd "$LEAD_MODEL") (x1)"
+echo "  Worker:   $(model_cmd "$WORKER_MODEL") (x$WORKERS)"
+[[ -n "$WORKFLOW" ]] && echo "  Workflow: $WORKFLOW"
+echo "  Dir:      $WORKDIR"
+
+# --- Create session with lead pane ---
+tmux new-session -d -s "$SESSION" -n main -c "$WORKDIR"
+
+LEAD_LABEL="${SESSION}-lead"
+tmux-bridge name "$SESSION:main.0" "$LEAD_LABEL"
+
+# --- Create worker panes ---
+WORKER_LABELS=()
+for i in $(seq 1 "$WORKERS"); do
+  tmux split-window -h -t "$SESSION:main" -c "$WORKDIR"
+  label="${SESSION}-worker-${i}"
+  WORKER_LABELS+=("$label")
+  tmux-bridge name "$SESSION:main.${i}" "$label"
+done
+
+# --- Layout + config ---
+tmux select-layout -t "$SESSION:main" even-horizontal
+tmux set-option -t "$SESSION" mode-keys vi
+tmux set-option -t "$SESSION" mouse on
+tmux bind-key Space select-layout even-horizontal
+
+# --- Inject env + launch workers ---
+WORKERS_CSV=$(IFS=,; echo "${WORKER_LABELS[*]}")
+
+for i in $(seq 1 "$WORKERS"); do
+  pane="$SESSION:main.${i}"
+  env_cmd="export ORCA=1 ORCA_ROLE=worker ORCA_PEER=$LEAD_LABEL ORCA_WORKER_ID=$i ORCA_ROOT=$WORKDIR"
+  [[ -n "$WORKFLOW" ]] && env_cmd="$env_cmd ORCA_WORKFLOW=$WORKFLOW"
+  tmux send-keys -t "$pane" "$env_cmd" Enter
+  launch_agent "$pane" "$WORKER_MODEL" "worker"
+done
+
+# --- Inject env + launch lead ---
+env_cmd="export ORCA=1 ORCA_ROLE=lead ORCA_WORKERS=$WORKERS_CSV ORCA_PEER=${WORKER_LABELS[0]} ORCA_ROOT=$WORKDIR"
+[[ -n "$WORKFLOW" ]] && env_cmd="$env_cmd ORCA_WORKFLOW=$WORKFLOW"
+tmux send-keys -t "$SESSION:main.0" "$env_cmd" Enter
+launch_agent "$SESSION:main.0" "$LEAD_MODEL" "lead"
+
+# --- Codex /clear re-activation monitors ---
+_skill_monitor() {
+  set +e
+  local session="$1" pane="$2" role="$3"
+  local skill_cmd="\$orca"
+  [[ "$role" == "lead" ]] && skill_cmd="/orca"
+
+  while tmux has-session -t "$session" 2>/dev/null; do
+    local out banner
+    out=$(tmux capture-pane -p -t "$pane" 2>/dev/null \
+      | perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g') || true
+    banner=$(echo "$out" | grep -c '>_ OpenAI Codex')
+    if [ "$banner" -gt 0 ] && ! echo "$out" | grep -q "$skill_cmd"; then
+      sleep 2
+      tmux send-keys -l -t "$pane" "$skill_cmd"
+    fi
+    sleep 3
+  done
+}
+
+# Kill old monitors
+for f in /tmp/orca-monitor-"${SESSION}"-*.pid; do
+  if [[ -f "$f" ]]; then
+    kill "$(cat "$f")" 2>/dev/null || true
+    rm -f "$f"
+  fi
+done
+
+# Start monitors for Codex panes
+if [[ "$WORKER_MODEL" == "codex" ]]; then
+  for i in $(seq 1 "$WORKERS"); do
+    _skill_monitor "$SESSION" "$SESSION:main.${i}" "worker" &
+    echo $! > "/tmp/orca-monitor-${SESSION}-worker-${i}.pid"
+  done
+fi
+
+if [[ "$LEAD_MODEL" == "codex" ]]; then
+  _skill_monitor "$SESSION" "$SESSION:main.0" "lead" &
+  echo $! > "/tmp/orca-monitor-${SESSION}-lead.pid"
+fi
+
+# --- Focus lead + attach ---
+tmux select-pane -t "$SESSION:main.0"
+tmux attach -t "$SESSION"
+```
+
+- [ ] **Step 2: Run shellcheck**
+
+Run: `shellcheck start.sh`
+Expected: no errors (warnings about `SC2207` for array assignment OK)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add start.sh
+git commit -m "feat: start.sh multi-worker support with --workers/--lead/--worker/--workflow"
+```
+
+---
+
+### Task 2: orca-worktree.sh
+
+**Files:**
+- Create: `orca-worktree.sh`
+
+- [ ] **Step 1: Create orca-worktree.sh**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ORCA_DIR="${ORCA_ROOT:-.}/.orca/worktree"
+
+usage() {
+  cat <<EOF
+Usage: orca-worktree {create|remove|list|clean} [id]
+
+Commands:
+  create <id>   Create worktree at .orca/worktree/<id>
+  remove <id>   Remove worktree and its branch
+  list          List orca worktrees
+  clean         Remove all orca worktrees
+EOF
+}
+
+cmd="${1:-}"
+id="${2:-}"
+
+case "$cmd" in
+  create)
+    [[ -z "$id" ]] && { echo "Error: id required" >&2; usage; exit 1; }
+    dir="$ORCA_DIR/$id"
+    branch="orca-${id}"
+    mkdir -p "$(dirname "$dir")"
+    git worktree add "$dir" -b "$branch"
+    echo "$dir"
+    ;;
+  remove)
+    [[ -z "$id" ]] && { echo "Error: id required" >&2; usage; exit 1; }
+    dir="$ORCA_DIR/$id"
+    git worktree remove "$dir" --force 2>/dev/null || true
+    git branch -D "orca-${id}" 2>/dev/null || true
+    echo "Removed $dir"
+    ;;
+  list)
+    git worktree list | grep "\.orca/worktree" || echo "No orca worktrees"
+    ;;
+  clean)
+    local count=0
+    while IFS= read -r wt; do
+      [[ -z "$wt" ]] && continue
+      git worktree remove "$wt" --force 2>/dev/null || true
+      # Extract branch name from worktree path
+      local wt_id
+      wt_id=$(basename "$wt")
+      git branch -D "orca-${wt_id}" 2>/dev/null || true
+      count=$((count + 1))
+    done < <(git worktree list --porcelain | grep "^worktree.*\.orca/worktree" | sed 's/^worktree //')
+    echo "Cleaned $count worktree(s)"
+    ;;
+  *)
+    usage
+    [[ -z "$cmd" ]] && exit 0
+    exit 1
+    ;;
+esac
+```
+
+Note: `local` inside `case` outside function won't work. Fix: move `clean` logic to avoid `local`:
+
+```bash
+  clean)
+    count=0
+    while IFS= read -r wt; do
+      [[ -z "$wt" ]] && continue
+      git worktree remove "$wt" --force 2>/dev/null || true
+      wt_id=$(basename "$wt")
+      git branch -D "orca-${wt_id}" 2>/dev/null || true
+      count=$((count + 1))
+    done < <(git worktree list --porcelain | grep "^worktree.*\.orca/worktree" | sed 's/^worktree //')
+    echo "Cleaned $count worktree(s)"
+    ;;
+```
+
+- [ ] **Step 2: Make executable + shellcheck**
+
+Run: `chmod +x orca-worktree.sh && shellcheck orca-worktree.sh`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add orca-worktree.sh
+git commit -m "feat: orca-worktree helper for git worktree management"
+```
+
+---
+
+### Task 3: stop.sh — worktree + multi-monitor cleanup
+
+**Files:**
+- Modify: `stop.sh`
+
+- [ ] **Step 1: Update stop.sh**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SESSION="orca-$(basename "$(pwd)")"
+
+if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+  echo "Session '$SESSION' does not exist"
+  exit 0
+fi
+
+echo "Panes in $SESSION:"
+tmux list-panes -t "$SESSION" -F "  #{pane_index}: #{pane_current_command} (pid: #{pane_pid})"
+
+echo ""
+read -rp "Stop $SESSION? [y/N] " confirm
+if [[ "$confirm" != [yY] ]]; then
+  echo "Cancelled"
+  exit 0
+fi
+
+# Kill all monitors for this session
+for f in /tmp/orca-monitor-"${SESSION}"-*.pid; do
+  if [[ -f "$f" ]]; then
+    kill "$(cat "$f")" 2>/dev/null || true
+    rm -f "$f"
+  fi
+done
+
+# Clean worktrees
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ -x "$SCRIPT_DIR/orca-worktree.sh" ]]; then
+  "$SCRIPT_DIR/orca-worktree.sh" clean 2>/dev/null || true
+fi
+
+# Clean heartbeat state
+rm -rf .orca/heartbeat 2>/dev/null || true
+
+tmux kill-session -t "$SESSION"
+echo "Stopped $SESSION"
+```
+
+- [ ] **Step 2: shellcheck**
+
+Run: `shellcheck stop.sh`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add stop.sh
+git commit -m "feat: stop.sh worktree cleanup and multi-monitor PID cleanup"
+```
+
+---
+
+### Task 4: hooks/ — heartbeat + idle check
+
+**Files:**
+- Create: `hooks/post-tool-use.sh` (worker heartbeat)
+- Create: `hooks/check-heartbeat.sh` (lead idle check)
+
+- [ ] **Step 1: Create hooks/post-tool-use.sh**
+
+```bash
+#!/usr/bin/env bash
+# PostToolUse hook: worker writes heartbeat timestamp.
+# Runs after every tool call. Fast — just a file write.
+[[ -z "${ORCA:-}" ]] && exit 0
+[[ "${ORCA_ROLE:-}" != "worker" ]] && exit 0
+
+HEARTBEAT_DIR="${ORCA_ROOT:-.}/.orca/heartbeat"
+mkdir -p "$HEARTBEAT_DIR"
+date +%s > "$HEARTBEAT_DIR/${ORCA_WORKER_ID:-0}"
+```
+
+- [ ] **Step 2: Create hooks/check-heartbeat.sh**
+
+```bash
+#!/usr/bin/env bash
+# PreToolUse hook: lead checks worker heartbeats before each tool call.
+# Outputs notification if any worker idle >30s.
+[[ -z "${ORCA:-}" ]] && exit 0
+[[ "${ORCA_ROLE:-}" != "lead" ]] && exit 0
+
+HEARTBEAT_DIR="${ORCA_ROOT:-.}/.orca/heartbeat"
+[[ ! -d "$HEARTBEAT_DIR" ]] && exit 0
+
+COOLDOWN=30
+now=$(date +%s)
+idle_workers=()
+total=0
+
+for f in "$HEARTBEAT_DIR"/[0-9]*; do
+  [[ -f "$f" ]] || continue
+  total=$((total + 1))
+  last=$(cat "$f")
+  gap=$((now - last))
+  id=$(basename "$f")
+  if (( gap > COOLDOWN )); then
+    idle_workers+=("worker-$id(${gap}s)")
+  fi
+done
+
+if (( ${#idle_workers[@]} > 0 )); then
+  if (( ${#idle_workers[@]} == total )); then
+    echo "[orca] All $total workers idle: ${idle_workers[*]}"
+  else
+    echo "[orca] Idle: ${idle_workers[*]}"
+  fi
+fi
+```
+
+- [ ] **Step 3: Make executable + shellcheck**
+
+Run: `chmod +x hooks/post-tool-use.sh hooks/check-heartbeat.sh && shellcheck hooks/post-tool-use.sh hooks/check-heartbeat.sh`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hooks/
+git commit -m "feat: heartbeat hooks — worker PostToolUse + lead PreToolUse idle check"
+```
+
+---
+
+### Task 5: install.sh — register new commands + hooks
+
+**Files:**
+- Modify: `install.sh`
+
+- [ ] **Step 1: Add orca-worktree command registration**
+
+After the existing `ln -sfn` block for global commands, add:
+
+```bash
+ln -sfn "$SCRIPT_DIR/orca-worktree.sh" ~/.local/bin/orca-worktree
+echo "[x] Global commands: orca, orca-stop, orca-idle, orca-worktree -> ~/.local/bin/"
+```
+
+(Update the existing echo line to include orca-worktree.)
+
+- [ ] **Step 2: Add PostToolUse hook for workers (CC)**
+
+After the existing SessionStart hook registration for Claude Code, add PostToolUse hook:
+
+```bash
+# Claude Code PostToolUse hook (worker heartbeat)
+if jq -e '.hooks.PostToolUse' "$CLAUDE_SETTINGS" &>/dev/null; then
+  echo "[x] Claude Code PostToolUse hook exists, skipping"
+else
+  POST_HOOK_TMP=$(mktemp)
+  cat > "$POST_HOOK_TMP" << HOOKEOF
+[{"hooks":[{"type":"command","command":"$SCRIPT_DIR/hooks/post-tool-use.sh"}]}]
+HOOKEOF
+  jq --slurpfile hook "$POST_HOOK_TMP" '.hooks.PostToolUse = $hook[0]' \
+    "$CLAUDE_SETTINGS" > "$CLAUDE_SETTINGS.tmp" && mv "$CLAUDE_SETTINGS.tmp" "$CLAUDE_SETTINGS"
+  rm -f "$POST_HOOK_TMP"
+  echo "[x] Claude Code PostToolUse hook registered (worker heartbeat)"
+fi
+```
+
+- [ ] **Step 3: Add PreToolUse hook for lead (CC)**
+
+```bash
+# Claude Code PreToolUse hook (lead heartbeat check)
+if jq -e '.hooks.PreToolUse' "$CLAUDE_SETTINGS" &>/dev/null; then
+  echo "[x] Claude Code PreToolUse hook exists, skipping"
+else
+  PRE_HOOK_TMP=$(mktemp)
+  cat > "$PRE_HOOK_TMP" << HOOKEOF
+[{"hooks":[{"type":"command","command":"$SCRIPT_DIR/hooks/check-heartbeat.sh"}]}]
+HOOKEOF
+  jq --slurpfile hook "$PRE_HOOK_TMP" '.hooks.PreToolUse = $hook[0]' \
+    "$CLAUDE_SETTINGS" > "$CLAUDE_SETTINGS.tmp" && mv "$CLAUDE_SETTINGS.tmp" "$CLAUDE_SETTINGS"
+  rm -f "$PRE_HOOK_TMP"
+  echo "[x] Claude Code PreToolUse hook registered (lead heartbeat check)"
+fi
+```
+
+- [ ] **Step 4: Add hooks for Codex**
+
+Similar to CC but writes to `~/.codex/hooks.json`:
+
+```bash
+# Codex PostToolUse hook
+if ! jq -e '.hooks.PostToolUse' "$CODEX_HOOKS" &>/dev/null; then
+  POST_HOOK_TMP=$(mktemp)
+  cat > "$POST_HOOK_TMP" << HOOKEOF
+[{"hooks":[{"type":"command","command":"$SCRIPT_DIR/hooks/post-tool-use.sh"}]}]
+HOOKEOF
+  jq --slurpfile hook "$POST_HOOK_TMP" '.hooks.PostToolUse = $hook[0]' \
+    "$CODEX_HOOKS" > "$CODEX_HOOKS.tmp" && mv "$CODEX_HOOKS.tmp" "$CODEX_HOOKS"
+  rm -f "$POST_HOOK_TMP"
+  echo "[x] Codex PostToolUse hook registered"
+fi
+```
+
+- [ ] **Step 5: Update SessionStart hook to use ORCA_ROLE**
+
+Replace the hardcoded role messages:
+
+```bash
+# Claude Code SessionStart hook — role-aware
+CLAUDE_HOOK_TMP=$(mktemp)
+cat > "$CLAUDE_HOOK_TMP" << 'HOOKEOF'
+[{"hooks":[{"type":"command","command":"if [ -n \"$ORCA\" ]; then echo \"Orca active. Role: ${ORCA_ROLE:-unknown}. Run /orca\"; fi"}]}]
+HOOKEOF
+```
+
+- [ ] **Step 6: shellcheck + commit**
+
+Run: `shellcheck install.sh`
+
+```bash
+git add install.sh
+git commit -m "feat: install.sh register orca-worktree, heartbeat hooks, role-aware SessionStart"
+```
+
+---
+
+### Task 6: skills/orca/SKILL.md — multi-worker update
+
+**Files:**
+- Modify: `skills/orca/SKILL.md`
+
+- [ ] **Step 1: Rewrite SKILL.md for multi-worker**
+
+```markdown
+---
+name: orca
+description: Multi-agent orchestration. Role set by $ORCA_ROLE (lead/worker).
+---
+
+# Orca
+
+Environment ready. Do not run any checks.
+
+## Role
+
+Read `$ORCA_ROLE`:
+- `lead` — dispatch workers, optimize, report user
+- `worker` — implement, self-review, report lead
+
+## Environment
+
+| Variable | Lead | Worker |
+|----------|------|--------|
+| `ORCA_ROLE` | `lead` | `worker` |
+| `ORCA_PEER` | first worker label | lead label |
+| `ORCA_WORKERS` | all worker labels (csv) | - |
+| `ORCA_WORKER_ID` | - | `1`, `2`, ... |
+| `ORCA_ROOT` | repo root | repo root |
+| `ORCA_WORKFLOW` | workflow name (optional) | workflow name (optional) |
+
+## Communication
+
+One command, always chain with `&&`:
+
+\`\`\`bash
+tmux-bridge read $ORCA_PEER 5 && tmux-bridge message $ORCA_PEER "msg" && tmux-bridge read $ORCA_PEER 5 && tmux-bridge keys $ORCA_PEER Enter
+\`\`\`
+
+Read Guard: must `read` before every `type`/`keys`.
+
+Multi-worker: use specific label from `$ORCA_WORKERS` instead of `$ORCA_PEER`.
+
+## Lead
+
+1. **Confirm** — discuss breakdown with user before dispatching
+2. **Dispatch** — for each worker, send: goal, scope, constraints, worktree path. End with: "Run /review, build, test. Fix issues, then report."
+   - Single worker: use `$ORCA_PEER`
+   - Multi-worker: iterate `$ORCA_WORKERS` (comma-separated), dispatch to each
+   - Worktree: run `orca-worktree create <id>` first, tell worker to `cd` into it
+3. **Wait** — say "dispatched, waiting" and **end turn**. Do not poll.
+   - Heartbeat: `[orca]` notifications appear automatically via PreToolUse hook
+4. **Optimize** — on report, /simplify changed files
+5. **Report** — summarize to user
+
+## Worker
+
+1. **Wait** — reply "Worker ready." and end turn
+2. **Implement** -> **Self-review** (/review, fix, repeat) -> **Test** (build + tests)
+3. **Report** — 1-2 sentence summary to lead, no code/diffs
+
+Workers can also initiate: ask lead for help or confirm approach.
+
+## Rules
+
+1. Read before type/keys
+2. One `&&` chain per communication
+3. No polling — heartbeat handles idle detection
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add skills/orca/SKILL.md
+git commit -m "feat: SKILL.md multi-worker support with env vars and heartbeat"
+```
+
+---
+
+### Task 7: Docs + PLAN.md update
+
+**Files:**
+- Modify: `PLAN.md`
+- Modify: `docs/ARCHITECTURE.md`
+
+- [ ] **Step 1: Update PLAN.md checkboxes**
+
+Mark P0 items as completed.
+
+- [ ] **Step 2: Update ARCHITECTURE.md**
+
+Add new decisions:
+- Role from env var (`$ORCA_ROLE`) not activation command
+- Heartbeat via hooks (PostToolUse write, PreToolUse check) — no background monitor needed
+- Worktree at `.orca/worktree/<id>` via `orca-worktree.sh`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add PLAN.md docs/ARCHITECTURE.md
+git commit -m "docs: update PLAN.md and ARCHITECTURE.md for P0 completion"
+```

--- a/hooks/check-heartbeat.sh
+++ b/hooks/check-heartbeat.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# PreToolUse hook: lead checks worker heartbeats.
+[[ -z "${ORCA:-}" ]] && exit 0
+[[ "${ORCA_ROLE:-}" != "lead" ]] && exit 0
+
+HEARTBEAT_DIR="${ORCA_ROOT:-.}/.orca/heartbeat"
+[[ ! -d "$HEARTBEAT_DIR" ]] && exit 0
+
+COOLDOWN=30
+now=$(date +%s)
+idle_workers=()
+total=0
+
+for f in "$HEARTBEAT_DIR"/[0-9]*; do
+  [[ -f "$f" ]] || continue
+  total=$((total + 1))
+  last=$(cat "$f")
+  gap=$((now - last))
+  id=$(basename "$f")
+  if (( gap > COOLDOWN )); then
+    idle_workers+=("worker-$id(${gap}s)")
+  fi
+done
+
+if (( ${#idle_workers[@]} > 0 )); then
+  if (( ${#idle_workers[@]} == total )); then
+    echo "[orca] All $total workers idle: ${idle_workers[*]}"
+  else
+    echo "[orca] Idle: ${idle_workers[*]}"
+  fi
+fi

--- a/hooks/post-tool-use.sh
+++ b/hooks/post-tool-use.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# PostToolUse hook: worker writes heartbeat timestamp.
+[[ -z "${ORCA:-}" ]] && exit 0
+[[ "${ORCA_ROLE:-}" != "worker" ]] && exit 0
+
+HEARTBEAT_DIR="${ORCA_ROOT:-.}/.orca/heartbeat"
+mkdir -p "$HEARTBEAT_DIR"
+date +%s > "$HEARTBEAT_DIR/${ORCA_WORKER_ID:-0}"

--- a/install.sh
+++ b/install.sh
@@ -81,13 +81,14 @@ for f in "$SCRIPT_DIR"/*.sh; do
 done
 echo "[x] Script permissions set"
 
-# --- Create global command ---
+# --- Create global commands ---
 # Single entry point. Subcommands (stop, idle, ...) dispatched inside start.sh.
 mkdir -p ~/.local/bin
 ln -sfn "$SCRIPT_DIR/start.sh" ~/.local/bin/orca
+ln -sfn "$SCRIPT_DIR/orca-worktree.sh" ~/.local/bin/orca-worktree
 # Clean up legacy per-subcommand symlinks from earlier installs (no-op if absent)
 rm -f ~/.local/bin/orca-stop ~/.local/bin/orca-idle
-echo "[x] Global command: orca -> ~/.local/bin/ (subcommands: stop, idle)"
+echo "[x] Global commands: orca, orca-worktree -> ~/.local/bin/"
 
 # --- Check ~/.local/bin in PATH ---
 if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
@@ -96,14 +97,16 @@ if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
   echo '  export PATH="$HOME/.local/bin:$PATH"'
 fi
 
-# --- Register skill ---
+# --- Register skills ---
 mkdir -p ~/.claude/skills
 ln -sfn "$SCRIPT_DIR/skills/orca" ~/.claude/skills/orca
-echo "[x] Skill registered at ~/.claude/skills/orca (Claude Code)"
+ln -sfn "$SCRIPT_DIR/skills/workflows/code" ~/.claude/skills/orca-code
+echo "[x] Skills registered: orca, orca-code -> ~/.claude/skills/"
 
 mkdir -p ~/.agents/skills
 ln -sfn "$SCRIPT_DIR/skills/orca" ~/.agents/skills/orca
-echo "[x] Skill registered at ~/.agents/skills/orca (Codex)"
+ln -sfn "$SCRIPT_DIR/skills/workflows/code" ~/.agents/skills/orca-code
+echo "[x] Skills registered: orca, orca-code -> ~/.agents/skills/"
 
 # --- Register SessionStart hooks ---
 
@@ -185,9 +188,48 @@ cleanup_orca_hook() {
 }
 
 # Claude Code hook
-install_or_update_hook ~/.claude/settings.json "$CLAUDE_HOOK_TMP" "Claude Code"
+CLAUDE_SETTINGS=~/.claude/settings.json
+install_or_update_hook "$CLAUDE_SETTINGS" "$CLAUDE_HOOK_TMP" "Claude Code"
 
-# Codex worker activation is fully owned by start.sh ($CODER_CMD '$orca' on
+# Claude Code PostToolUse hook (worker heartbeat)
+if jq -e '.hooks.PostToolUse' "$CLAUDE_SETTINGS" &>/dev/null; then
+  echo "[x] Claude Code PostToolUse hook exists, skipping"
+else
+  POST_HOOK_TMP=$(mktemp)
+  cat > "$POST_HOOK_TMP" << HOOKEOF
+[{"hooks":[{"type":"command","command":"$SCRIPT_DIR/hooks/post-tool-use.sh"}]}]
+HOOKEOF
+  if jq --slurpfile hook "$POST_HOOK_TMP" '.hooks.PostToolUse = $hook[0]' \
+    "$CLAUDE_SETTINGS" > "$CLAUDE_SETTINGS.tmp"; then
+    mv "$CLAUDE_SETTINGS.tmp" "$CLAUDE_SETTINGS"
+    echo "[x] Claude Code PostToolUse hook registered (worker heartbeat)"
+  else
+    rm -f "$CLAUDE_SETTINGS.tmp"
+    echo "[!] Claude Code PostToolUse hook install failed" >&2
+  fi
+  rm -f "$POST_HOOK_TMP"
+fi
+
+# Claude Code PreToolUse hook (lead heartbeat check)
+if jq -e '.hooks.PreToolUse' "$CLAUDE_SETTINGS" &>/dev/null; then
+  echo "[x] Claude Code PreToolUse hook exists, skipping"
+else
+  PRE_HOOK_TMP=$(mktemp)
+  cat > "$PRE_HOOK_TMP" << HOOKEOF
+[{"hooks":[{"type":"command","command":"$SCRIPT_DIR/hooks/check-heartbeat.sh"}]}]
+HOOKEOF
+  if jq --slurpfile hook "$PRE_HOOK_TMP" '.hooks.PreToolUse = $hook[0]' \
+    "$CLAUDE_SETTINGS" > "$CLAUDE_SETTINGS.tmp"; then
+    mv "$CLAUDE_SETTINGS.tmp" "$CLAUDE_SETTINGS"
+    echo "[x] Claude Code PreToolUse hook registered (lead heartbeat check)"
+  else
+    rm -f "$CLAUDE_SETTINGS.tmp"
+    echo "[!] Claude Code PreToolUse hook install failed" >&2
+  fi
+  rm -f "$PRE_HOOK_TMP"
+fi
+
+# Codex worker activation is fully owned by start.sh (launch_agent '$orca' on
 # launch + _skill_monitor banner-watcher after /clear), so codex needs no
 # SessionStart hook from us. Strip any legacy orca-managed entry from prior
 # installs so codex's hook runner doesn't choke on a stale `[ -n "$ORCA" ]`

--- a/orca-worktree.sh
+++ b/orca-worktree.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# orca-worktree — manage git worktrees for orca workers
+# ---------------------------------------------------------------------------
+
+ORCA_DIR="${ORCA_ROOT:-.}/.orca/worktree"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command> [args]
+
+Commands:
+  create <id>   Create worktree at $ORCA_DIR/<id> on branch orca-<id>
+  remove <id>   Remove worktree and delete branch orca-<id>
+  list          List active orca worktrees
+  clean         Remove all orca worktrees
+EOF
+}
+
+cmd="${1:-}"
+
+case "$cmd" in
+  create)
+    id="${2:?create requires an <id>}"
+    dir="${ORCA_DIR}/${id}"
+    branch="orca-${id}"
+    mkdir -p "$(dirname "$dir")"
+    git worktree add "$dir" -b "$branch"
+    echo "$dir"
+    ;;
+
+  remove)
+    id="${2:?remove requires an <id>}"
+    dir="${ORCA_DIR}/${id}"
+    branch="orca-${id}"
+    git worktree remove "$dir" --force 2>/dev/null || true
+    git branch -D "$branch" 2>/dev/null || true
+    echo "Removed $dir"
+    ;;
+
+  list)
+    if ! git worktree list | grep -q "\.orca/worktree"; then
+      echo "No orca worktrees"
+    else
+      git worktree list | grep "\.orca/worktree"
+    fi
+    ;;
+
+  clean)
+    worktrees="$(git worktree list --porcelain | { grep "^worktree.*\.orca/worktree" || true; } | sed 's/^worktree //')"
+    count=0
+    while IFS= read -r wt_path; do
+      [ -z "$wt_path" ] && continue
+      git worktree remove --force "$wt_path" 2>/dev/null || true
+      git branch -D "orca-$(basename "$wt_path")" 2>/dev/null || true
+      count=$((count + 1))
+    done <<< "$worktrees"
+    echo "Cleaned ${count} worktree(s)"
+    ;;
+
+  "")
+    usage
+    exit 0
+    ;;
+
+  *)
+    echo "Unknown command: $cmd" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/skills/orca/SKILL.md
+++ b/skills/orca/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orca
-description: Multi-agent orchestration via /orca (lead) or $orca (worker).
+description: Multi-agent orchestration. Role set by $ORCA_ROLE (lead/worker).
 ---
 
 # Orca
@@ -9,32 +9,57 @@ Environment ready. Do not run any checks.
 
 ## Role
 
-- `/orca` → **Lead**: dispatch workers, /simplify optimize, report user
-- `$orca` → **Worker**: implement, /review self-check, report lead
+Read `$ORCA_ROLE`:
+- `lead` — dispatch workers, optimize, report user
+- `worker` — implement, self-review, report lead
+
+## Environment
+
+| Variable | Lead | Worker |
+|----------|------|--------|
+| `ORCA_ROLE` | `lead` | `worker` |
+| `ORCA_PEER` | first worker label | lead label |
+| `ORCA_WORKERS` | all worker labels (csv) | - |
+| `ORCA_WORKER_ID` | - | `1`, `2`, ... |
+| `ORCA_ROOT` | repo root | repo root |
+| `ORCA_WORKFLOW` | workflow name (optional) | workflow name (optional) |
+
+## Workflow
+
+If `$ORCA_WORKFLOW` is set, invoke the workflow skill after this skill loads:
+- `code` → invoke `orca-code` skill (Claude Code: `/orca-code`, Codex: `$orca-code`)
 
 ## Communication
 
 One command, always chain with `&&`:
 
-```bash
+````bash
 tmux-bridge read $ORCA_PEER 5 && tmux-bridge message $ORCA_PEER "msg" && tmux-bridge read $ORCA_PEER 5 && tmux-bridge keys $ORCA_PEER Enter
-```
+````
 
 Read Guard: must `read` before every `type`/`keys`.
+
+Multi-worker: use specific label from `$ORCA_WORKERS` instead of `$ORCA_PEER`.
 
 ## Lead
 
 1. **Confirm** — discuss breakdown with user before dispatching
-2. **Dispatch** — goal, scope, constraints, acceptance criteria. Complex tasks: ask for plan first. Large tasks: write `.agents/handoff/` doc. End with: "Run /review, build, test. Fix issues, then report."
-3. **Wait** — say "dispatched, waiting" and **end turn**. Do not read/poll/check worker.
+2. **Dispatch** — for each worker, send: goal, scope, constraints, worktree path. End with: "Run /review, build, test. Fix issues, then report."
+   - Single worker: use `$ORCA_PEER`
+   - Multi-worker: iterate `$ORCA_WORKERS` (comma-separated), dispatch to each
+   - Worktree: run `orca-worktree create <id>` first, tell worker to `cd` into it
+   - **Long-context tasks**: write full plan to `/tmp/orca-handoff-<task-slug>-<timestamp>.md` and tell worker to read that path. Survives tmux-bridge truncation and context compaction.
+3. **Wait** — say "dispatched, waiting" and **end turn**. Do not poll.
+   - Heartbeat: `[orca]` idle notifications surface on lead's next tool use (PreToolUse hook). For immediate awareness, `tmux-bridge read <worker>` to check pane.
+   - Idle = no tool calls in 30s. Could mean done, stuck, or waiting. Check worker pane to determine next action.
 4. **Optimize** — on report, /simplify changed files
 5. **Report** — summarize to user
 
 ## Worker
 
 1. **Wait** — reply "Worker ready." in own pane (do not message lead) and end turn
-2. **Implement** → **Self-review** (/review, fix, repeat) → **Test** (build + tests)
-3. **Report** — 1-2 sentence summary, no code/diffs
+2. **Implement** -> **Self-review** (/review, fix, repeat) -> **Test** (build + tests)
+3. **Report** — 1-2 sentence summary to lead, no code/diffs
 
 Workers can also initiate: ask lead for help or confirm approach.
 
@@ -42,4 +67,4 @@ Workers can also initiate: ask lead for help or confirm approach.
 
 1. Read before type/keys
 2. One `&&` chain per communication
-3. No polling
+3. No polling — heartbeat handles idle detection

--- a/skills/workflows/code/SKILL.md
+++ b/skills/workflows/code/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: orca-code
+description: Code workflow for Orca lead. Parallel implementation + merge + optimize.
+---
+
+# Code Workflow
+
+For lead only. If `$ORCA_ROLE` != `lead`, ignore this workflow.
+
+Activated via `--workflow code` or invoke `orca-code` skill manually.
+
+## 1. Plan
+
+Break the user's request into independent sub-tasks. Each task must:
+- Touch different files/modules (no overlap between workers)
+- Be completable by one worker in isolation
+- Have clear scope and acceptance criteria
+
+Confirm breakdown with user before dispatching.
+
+## 2. Dispatch
+
+For each task, up to N workers (from `$ORCA_WORKERS`):
+
+```bash
+# 1. Create isolated worktree
+worktree_path=$(orca-worktree create task-1)
+
+# 2. Short tasks: inline in message
+tmux-bridge read <worker> 5 && \
+tmux-bridge message <worker> "Task: <description>
+Worktree: cd $worktree_path
+Scope: <files to change>
+Criteria: <what done looks like>
+When done: /review, build, test. Fix issues, then report back." && \
+tmux-bridge read <worker> 5 && \
+tmux-bridge keys <worker> Enter
+
+# 3. Long-context tasks: write file, send pointer
+plan_path="/tmp/orca-handoff-task-1-$(date +%s).md"
+cat > "$plan_path" <<PLAN
+[full plan with all context, constraints, file refs]
+PLAN
+tmux-bridge message <worker> "Read $plan_path and execute.
+Worktree: cd $worktree_path
+When done: /review, build, test, then report back."
+```
+
+Replace `<worker>` with specific label from `$ORCA_WORKERS`.
+
+If more tasks than workers: queue remaining, dispatch when a worker reports done.
+
+## 3. Wait
+
+Say "Dispatched N workers, waiting." and **end turn**.
+
+Worker reports arrive via tmux-bridge message (push). Idle notifications surface on next tool use via heartbeat hook. Idle = no tool calls in 30s — could mean done, stuck, or waiting. Check worker pane to confirm.
+
+## 4. Merge
+
+First-done-first-merge. For each completed worker:
+
+```bash
+# Detect base branch
+base_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+base_branch="${base_branch:-main}"
+
+# Review changes
+git -C .orca/worktree/task-1 log --oneline "$base_branch..HEAD"
+git -C .orca/worktree/task-1 diff "$base_branch"
+
+# Merge into current branch
+git merge --no-commit orca-task-1
+
+# Inspect staged changes. If clean:
+git commit -m "merge: task-1 from worker"
+
+# Clean up
+orca-worktree remove task-1
+```
+
+**Conflict handling:**
+- Merge in first-done-first-merge order
+- Use `--no-commit` to inspect before finalizing
+- Auto-resolve trivial conflicts (whitespace, import order)
+- Escalate semantic conflicts to user
+- After resolving, run `/review` on merged result before optimizing
+
+## 5. Optimize
+
+Run `/simplify` on all files changed across workers.
+
+## 6. Report
+
+Summarize to user:
+- What was requested vs what was built
+- Per-worker summary (1 line each)
+- Issues encountered (if any)
+- Next steps (if any)

--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Subcommand dispatcher. start.sh is the single entry point installed as
 # `orca`; named subcommands route to sibling scripts, anything else falls
-# through to the start logic below (so `orca codex` still works).
+# through to the start logic below.
 # Resolve symlinks portably (macOS BSD readlink has no -f) so dispatch works
 # when invoked via ~/.local/bin/orca → /path/to/repo/start.sh.
 _orca_src="${BASH_SOURCE[0]}"
@@ -20,10 +20,10 @@ case "${1:-}" in
   ps)    shift; exec "$SCRIPT_DIR/ps.sh"            "$@" ;;
   rm)    shift; exec "$SCRIPT_DIR/rm.sh"            "$@" ;;
   prune) shift; exec "$SCRIPT_DIR/prune.sh"         "$@" ;;
-  "")    ;;  # no arg → start with defaults
+  ""|-*) ;;  # no arg or flags → fall through to start logic
   *)
     echo "Error: unknown command '$1'" >&2
-    echo "Usage: orca [stop|idle|ps|rm|prune]" >&2
+    echo "Usage: orca [stop|idle|ps|rm|prune] [--workers N] [--lead MODEL] [--worker MODEL] [--workflow NAME]" >&2
     exit 1
     ;;
 esac
@@ -31,18 +31,64 @@ esac
 # Sanitize basename: tmux uses `.` and `:` as target separators
 # (session:window.pane), so dirs containing them break tmux targeting.
 SESSION="orca-$(basename "$(pwd)" | tr '.:' '--')"
-# Per-instance dedicated tmux server (D8): isolates orca from the user's main
+# Per-instance dedicated tmux server: isolates orca from the user's main
 # tmux server so stop=kill-server gives a clean env on next start, and orca
 # never pollutes / inherits stale env from the user's long-lived server.
 SOCKET="$SESSION"
 TMUX_CMD="tmux -L $SOCKET"
-# Worker is hardcoded to codex. The previous `${1:-codex}` parameterization
-# was misleading (claude is the lead, hardcoded below) and the swap variant
-# (`orca codex` = codex lead + claude worker) needs SKILL.md role detection +
-# both agents' activation channels reworked. Tracked as D9 in PLAN.md.
-CODER_BIN="codex"
-CODER_ARGS="--sandbox danger-full-access -a on-request -c features.codex_hooks=true"
-CODER_CMD="$CODER_BIN $CODER_ARGS"
+
+# --- Defaults ---
+CODEX_DEFAULT_CMD="codex --sandbox danger-full-access -a on-request -c features.codex_hooks=true"
+WORKERS=1
+LEAD_MODEL="claude"
+WORKER_MODEL="codex"
+WORKFLOW=""
+
+# --- Usage ---
+usage() {
+  cat <<EOF
+Usage: orca [COMMAND] [OPTIONS]
+
+Commands:
+  stop          Stop current instance
+  idle          Wait for idle
+  ps            List instances
+  rm <name|id>  Remove instance
+  prune         Clean dead sockets
+
+Start options:
+  -n, --workers N      Number of workers (default: 1)
+      --lead MODEL     Lead model: claude|codex|<binary> (default: claude)
+      --worker MODEL   Worker model: claude|codex|<binary> (default: codex)
+  -w, --workflow NAME  Workflow skill (sets ORCA_WORKFLOW)
+  -h, --help           Show this help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n|--workers)  WORKERS="${2:?--workers requires a value}"; shift 2 ;;
+    --lead)        LEAD_MODEL="${2:?--lead requires a value}"; shift 2 ;;
+    --worker)      WORKER_MODEL="${2:?--worker requires a value}"; shift 2 ;;
+    -w|--workflow) WORKFLOW="${2:?--workflow requires a value}"; shift 2 ;;
+    -h|--help)     usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+# --- Model command mapping ---
+model_cmd() {
+  case "$1" in
+    claude) echo "claude" ;;
+    codex)  echo "$CODEX_DEFAULT_CMD" ;;
+    *)      echo "$1" ;;
+  esac
+}
+
+model_bin() {
+  local cmd; cmd="$(model_cmd "$1")"
+  echo "${cmd%% *}"
+}
 
 # --- Prerequisites ---
 if ! command -v tmux &>/dev/null; then
@@ -56,8 +102,15 @@ if ! command -v tmux-bridge &>/dev/null; then
   exit 1
 fi
 
-if ! command -v "$CODER_BIN" &>/dev/null; then
-  echo "Error: $CODER_BIN not installed" >&2
+LEAD_BIN="$(model_bin "$LEAD_MODEL")"
+if ! command -v "$LEAD_BIN" &>/dev/null; then
+  echo "Error: lead binary '$LEAD_BIN' not found" >&2
+  exit 1
+fi
+
+WORKER_BIN="$(model_bin "$WORKER_MODEL")"
+if ! command -v "$WORKER_BIN" &>/dev/null; then
+  echo "Error: worker binary '$WORKER_BIN' not found" >&2
   exit 1
 fi
 
@@ -70,17 +123,34 @@ fi
 # --- Working directory ---
 WORKDIR="${ORCA_WORKDIR:-$(pwd)}"
 
-# --- Create session ---
-echo "Starting $SESSION ..."
-echo "  Lead:   claude"
-echo "  Worker: $CODER_CMD"
-echo "  Dir:    $WORKDIR"
+# --- Build worker labels (space-separated, bash 3.2 compat) ---
+WORKER_LABELS=""
+i=1
+while [ "$i" -le "$WORKERS" ]; do
+  label="${SESSION}-worker-${i}"
+  WORKER_LABELS="${WORKER_LABELS}${WORKER_LABELS:+ }${label}"
+  i=$((i + 1))
+done
+WORKERS_CSV="$(echo "$WORKER_LABELS" | tr ' ' ',')"
+FIRST_WORKER_LABEL="${WORKER_LABELS%% *}"
 
-# Create session with lead pane (left)
+# --- Startup info ---
+echo "Starting $SESSION ..."
+echo "  Lead:    $LEAD_MODEL ($(model_cmd "$LEAD_MODEL"))"
+echo "  Worker:  $WORKER_MODEL ($(model_cmd "$WORKER_MODEL"))"
+echo "  Workers: $WORKERS"
+echo "  Dir:     $WORKDIR"
+[ -n "$WORKFLOW" ] && echo "  Workflow: $WORKFLOW"
+
+# --- Create session with lead pane (left) ---
 $TMUX_CMD new-session -d -s "$SESSION" -n main -c "$WORKDIR"
 
-# Split worker pane (right, 50% width)
-$TMUX_CMD split-window -h -t "$SESSION:main" -c "$WORKDIR"
+# --- Create worker panes ---
+i=1
+while [ "$i" -le "$WORKERS" ]; do
+  $TMUX_CMD split-window -h -t "$SESSION:main" -c "$WORKDIR"
+  i=$((i + 1))
+done
 
 # --- Even layout ---
 $TMUX_CMD select-layout -t "$SESSION:main" even-horizontal
@@ -105,52 +175,99 @@ if ! $TMUX_CMD show-options -gs terminal-features 2>/dev/null | grep -q ':hyperl
 fi
 
 # --- Name panes (session-prefixed for multi-instance isolation) ---
-LEAD_LABEL="${SESSION}-lead"
-CODER_LABEL="${SESSION}-coder"
 # tmux-bridge auto-detects the socket via $TMUX inside panes, but `name` is
 # called from this script (outside any pane), so pass socket explicitly.
-# Ask tmux for its actual socket path (portable across macOS / Linux).
 SOCKET_PATH=$($TMUX_CMD display-message -p -t "$SESSION" '#{socket_path}')
+LEAD_LABEL="${SESSION}-lead"
 TMUX_BRIDGE_SOCKET="$SOCKET_PATH" tmux-bridge name "$SESSION:main.0" "$LEAD_LABEL"
-TMUX_BRIDGE_SOCKET="$SOCKET_PATH" tmux-bridge name "$SESSION:main.1" "$CODER_LABEL"
+i=1
+for label in $WORKER_LABELS; do
+  TMUX_BRIDGE_SOCKET="$SOCKET_PATH" tmux-bridge name "$SESSION:main.${i}" "$label"
+  i=$((i + 1))
+done
 
-# --- Inject env ---
-$TMUX_CMD send-keys -t "$SESSION:main.0" "export ORCA=1 ORCA_PEER=$CODER_LABEL" Enter
-$TMUX_CMD send-keys -t "$SESSION:main.1" "export ORCA=1 ORCA_PEER=$LEAD_LABEL" Enter
+# --- Launch agent helper ---
+launch_agent() {
+  local pane="$1" model="$2" role="$3"
+  local cmd; cmd="$(model_cmd "$model")"
+  local bin="${cmd%% *}"
+  if [ "$bin" = "codex" ]; then
+    if [ "$role" = "worker" ]; then
+      $TMUX_CMD send-keys -t "$pane" "$cmd '\$orca'" Enter
+    else
+      $TMUX_CMD send-keys -t "$pane" "$cmd '/orca'" Enter
+    fi
+  else
+    $TMUX_CMD send-keys -t "$pane" "$cmd" Enter
+  fi
+}
 
-# --- Launch agents ---
-$TMUX_CMD send-keys -t "$SESSION:main.0" "claude" Enter
-# Codex: pass $orca as initial prompt to auto-activate skill
-$TMUX_CMD send-keys -t "$SESSION:main.1" "$CODER_CMD '\$orca'" Enter
+# --- Inject env + launch workers ---
+i=1
+for label in $WORKER_LABELS; do
+  pane="$SESSION:main.${i}"
+  env_cmd="export ORCA=1 ORCA_ROLE=worker ORCA_PEER=${LEAD_LABEL} ORCA_WORKER_ID=${i} ORCA_ROOT=${WORKDIR}"
+  [ -n "$WORKFLOW" ] && env_cmd="${env_cmd} ORCA_WORKFLOW=${WORKFLOW}"
+  $TMUX_CMD send-keys -t "$pane" "$env_cmd" Enter
+  launch_agent "$pane" "$WORKER_MODEL" "worker"
+  i=$((i + 1))
+done
+
+# --- Inject env + launch lead ---
+lead_env="export ORCA=1 ORCA_ROLE=lead ORCA_WORKERS=${WORKERS_CSV} ORCA_PEER=${FIRST_WORKER_LABEL} ORCA_ROOT=${WORKDIR}"
+[ -n "$WORKFLOW" ] && lead_env="${lead_env} ORCA_WORKFLOW=${WORKFLOW}"
+$TMUX_CMD send-keys -t "$SESSION:main.0" "$lead_env" Enter
+launch_agent "$SESSION:main.0" "$LEAD_MODEL" "lead"
 
 # --- /clear re-activation monitor ---
-# After Codex /clear, monitor detects welcome screen and inputs $orca
-# User must press Enter manually (tmux can't send Enter to Codex ratatui TUI)
+# After Codex /clear, monitor detects welcome screen and inputs the skill cmd.
+# User must press Enter manually (tmux can't send Enter to Codex ratatui TUI).
 _skill_monitor() {
   set +e
-  local session="$1" pane="$2"
+  local session="$1" pane="$2" role="$3"
+  local skill_cmd
+  if [ "$role" = "worker" ]; then
+    # shellcheck disable=SC2016  # $orca is a literal codex skill command, not a variable
+    skill_cmd='$orca'
+  else
+    skill_cmd='/orca'
+  fi
   while $TMUX_CMD has-session -t "$session" 2>/dev/null; do
     local out banner
     out=$($TMUX_CMD capture-pane -p -t "$pane" 2>/dev/null \
       | perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g') || true
-    banner=$(echo "$out" | grep -c '>_ OpenAI Codex')
-    if [ "$banner" -gt 0 ] && ! echo "$out" | grep -q '\$orca'; then
+    banner=$(echo "$out" | grep -c '>_ OpenAI Codex' || true)
+    if [ "$banner" -gt 0 ] && ! echo "$out" | grep -q "$skill_cmd"; then
       sleep 2
-      $TMUX_CMD send-keys -l -t "$pane" '$orca'
+      $TMUX_CMD send-keys -l -t "$pane" "$skill_cmd"
     fi
     sleep 3
   done
 }
 
-# Kill old monitor
-MONITOR_PID="/tmp/orca-monitor-${SESSION}.pid"
-if [ -f "$MONITOR_PID" ]; then
-  kill "$(cat "$MONITOR_PID")" 2>/dev/null || true
-  rm -f "$MONITOR_PID"
+# --- Kill old monitors ---
+for pid_file in /tmp/orca-monitor-"${SESSION}"-*.pid; do
+  [ -f "$pid_file" ] || continue
+  kill "$(cat "$pid_file")" 2>/dev/null || true
+  rm -f "$pid_file"
+done
+
+# --- Start monitors for codex panes ---
+WORKER_BIN_CHECK="$(model_bin "$WORKER_MODEL")"
+if [ "$WORKER_BIN_CHECK" = "codex" ]; then
+  i=1
+  for label in $WORKER_LABELS; do
+    _skill_monitor "$SESSION" "$SESSION:main.${i}" "worker" &
+    echo $! > "/tmp/orca-monitor-${SESSION}-worker-${i}.pid"
+    i=$((i + 1))
+  done
 fi
 
-_skill_monitor "$SESSION" "$SESSION:main.1" &
-echo $! > "$MONITOR_PID"
+LEAD_BIN_CHECK="$(model_bin "$LEAD_MODEL")"
+if [ "$LEAD_BIN_CHECK" = "codex" ]; then
+  _skill_monitor "$SESSION" "$SESSION:main.0" "lead" &
+  echo $! > "/tmp/orca-monitor-${SESSION}-lead.pid"
+fi
 
 # --- Focus lead pane ---
 $TMUX_CMD select-pane -t "$SESSION:main.0"

--- a/stop.sh
+++ b/stop.sh
@@ -47,11 +47,27 @@ if [[ "$confirm" != [yY] ]]; then
   exit 0
 fi
 
+# Kill all monitor processes for this session
+for pid_file in /tmp/orca-monitor-"${SESSION}"-*.pid; do
+  [ -f "$pid_file" ] || continue
+  kill "$(cat "$pid_file")" 2>/dev/null || true
+  rm -f "$pid_file"
+done
+# Legacy single-pid monitor (pre-multi-worker)
 MONITOR_PID="/tmp/orca-monitor-${SESSION}.pid"
 if [ -f "$MONITOR_PID" ]; then
   kill "$(cat "$MONITOR_PID")" 2>/dev/null || true
   rm -f "$MONITOR_PID"
 fi
+
+# Clean up worktrees
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -x "$SCRIPT_DIR/orca-worktree.sh" ]; then
+  "$SCRIPT_DIR/orca-worktree.sh" clean 2>/dev/null || true
+fi
+
+# Clean up heartbeat state
+rm -rf .orca/heartbeat 2>/dev/null || true
 
 if $HAS_DEDICATED; then
   # Kill the dedicated server (not just the session). This is what gives the


### PR DESCRIPTION
## Summary

基于最新 master（含 D8 tmux server、subcommand dispatcher、ps/rm/prune）rebase。
已处理所有 review 反馈。

**核心功能：**
- `orca --workers 3 --lead claude --worker codex --workflow code` — 多 worker、model-agnostic
- `orca-worktree create/remove/list/clean` — git worktree 隔离
- PostToolUse/PreToolUse hooks — 心跳机制（无后台 monitor，纯 hook）
- Code workflow skill — Plan → Dispatch → Wait → Merge → Optimize → Report
- `$ORCA_ROLE` env var — 角色判定从激活命令改为环境变量，解决 D9

**Review 修复：**
- P0-1: 心跳限制文档化（notifications surface on next tool use）
- P0-2: `{ grep ... || true; }` 修复 worktree clean 空匹配
- P0-4: dispatch 示例先解析路径再内联
- P0-5: workflow 调用语义明确（CC `/orca-code`、Codex `$orca-code`）
- P1-6: `git symbolic-ref` 动态检测 base branch
- P1-7: idle ≠ done 明确说明
- P1-8: merge conflict 策略（`--no-commit`、trivial 自动解决、语义冲突交用户）
- P2-9: workflow skill 加 lead-only guard
- P2-10: 提取 `CODEX_DEFAULT_CMD` 常量
- Handoff 提案: `/tmp/orca-handoff-<slug>-<timestamp>.md` 模式

## Changes

| File | Change |
|------|--------|
| `start.sh` | CLI flags, model_cmd/launch_agent, multi-worker panes, $TMUX_CMD, $SOCKET_PATH |
| `orca-worktree.sh` | New: git worktree 管理 |
| `stop.sh` | worktree + heartbeat 清理，multi-monitor PID glob |
| `hooks/post-tool-use.sh` | New: worker 心跳（纯文件写入，零 LLM token） |
| `hooks/check-heartbeat.sh` | New: lead idle 检测（30s cooldown） |
| `install.sh` | 注册 orca-worktree、workflow skills、PostToolUse/PreToolUse hooks |
| `skills/orca/SKILL.md` | $ORCA_ROLE、env var 表、workflow 段、handoff doc、idle 限制说明 |
| `skills/workflows/code/SKILL.md` | New: code workflow（含 handoff 模式、conflict 策略） |
| `PLAN.md` | P0 checkboxes、P1 code workflow 标记 |
| `docs/ARCHITECTURE.md` | 新架构决策（heartbeat、worktree、handoff） |

## Deferred

- P0-3: hook 注册模式改为通用化 `install_or_update_hook` — 需要重构，scope 较大，follow-up
- P0-1 后台 monitor 方案 — 计划在 P3 Worker Lifecycle 实现

## Test plan

- [ ] `shellcheck` passes on all `.sh` files
- [ ] `orca --help` shows new flags
- [ ] `orca --workers 2` creates 3 panes (lead + 2 workers)
- [ ] `orca --lead claude --worker codex` launches correct binaries
- [ ] `orca-worktree create test-1` creates `.orca/worktree/test-1`
- [ ] `orca-worktree clean` on empty repo doesn't error
- [ ] `orca stop` cleans up worktrees and heartbeat state
- [ ] Code workflow e2e: dispatch → parallel code → merge → report

🤖 Generated with [Claude Code](https://claude.com/claude-code)