### PR TITLE
docs: stably/orca 研究归档与 mixed/PLAN 围绕 Tier 1 重构

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -82,6 +82,97 @@ orca --lead claude --worker codex --workers 3 --workflow code
 - [x] Pre-D8 legacy session cleanup in `stop.sh` (orphan sessions on user's main tmux are detected + removed alongside dedicated)
 - [x] Sanitize `.` and `:` in dir basename (pre-existing bug surfaced during D8 smoke test)
 
+## 通信层重构（Tier 1：paste-buffer）
+
+**起源**：`docs/research/stably-orca-compare.md` 指出，`docs/proposals/mixed.md` 中 #1 和 #2（以及部分 #3）的根因是「将结构化指令塞入 shell 命令参数」。
+
+**目标**：让 `tmux-bridge` 的内容传递路径绕开 bash 解析。
+
+**方案**：将 `send-keys -l` 的内容通道替换为 `tmux load-buffer + paste-buffer`。
+- 新增 `tmux-bridge message-file <target> <path>` 子命令
+- 内部实现：`tmx load-buffer -b <name> <path> && tmx paste-buffer -t <target> -b <name>`
+- 原 `send-keys` 仍用于控制按键（Enter、Esc 等）
+
+**范围**
+- [ ] `tmux-bridge` `message-file` 子命令
+- [ ] Smoke test：Claude Code / Codex 在 bracketed paste 下的行为验证
+- [ ] `skills/orca/SKILL.md` 通信规则更新：结构化内容一律走 `message-file`
+- [ ] `docs/proposals/mixed.md` #1 收尾：方案 A/B 仍作为 fallback，但不再是主线
+
+**不在本范围内**（推迟到 Tier 2/3，详见研究文档）
+- Agent 原生 hook 注入（按 agent 单独适配，脆弱）
+- Sidecar RPC 进程（接近 stably Electron 模式，过重）
+
+**待澄清**
+- 不同 agent 对 bracketed paste 的兼容性
+- buffer 名称管理与清理策略
+
+## 待落地的 Skill 规则（留到独立的实施 PR）
+
+以下规则会直接修改 `skills/orca/SKILL.md`，merge 后立刻改变 worker 行为。本 PR 是研究 + 规划范畴，特意将这些规则拆出来，放到独立 PR 单独 review 与 smoke test。
+
+### 规则 1：Worker → Lead 汇报 fallback（过渡方案，等 Tier 1 落地后被取代）
+
+插入位置：`## Communication` 段的 `Multi-worker:` 行之后。
+
+```markdown
+Worker → Lead reply rules:
+> Current solution. Will be superseded by Tier 1 (paste-buffer) once landed; see `PLAN.md` "通信层重构（Tier 1：paste-buffer）".
+
+- Single-line short message (no backticks, no `$`, no newlines) → keep inline, wrap body in single quotes
+- Multi-line / contains backticks / contains `$` / contains markdown code block / needs cross-worker reuse → write report to `/tmp/orca-msg-<task-slug>-<timestamp>.md`, reuse the dispatch handoff slug, then send only the path
+
+​````bash
+msg_path="/tmp/orca-msg-auth-refactor-$(date +%s).md"
+cat > "$msg_path" <<'EOF'
+Full report body can include `code`, $VARS, 'quotes', and real newlines.
+EOF
+tmux-bridge read "$ORCA_PEER" 5 && tmux-bridge message "$ORCA_PEER" "Read $msg_path" && tmux-bridge read "$ORCA_PEER" 5 && tmux-bridge keys "$ORCA_PEER" Enter
+​````
+```
+
+另外在 `## Lead` 第 2 步「Long-context tasks」那条之后追加：
+
+```markdown
+- Symmetric for worker → lead reports; see Communication > Worker → Lead reply rules.
+```
+
+并在 `## Worker` 第 3 步的 Report 行末尾追加 `(follow Communication rules for inline vs file)`。
+
+**起源**：本 PR 中暴露的漏洞 —— `mixed.md` 宣称落盘是 fallback，但 `SKILL.md` 内并不存在对应的可执行规则。
+
+### 规则 2：Worktree 文件系统访问约定
+
+插入位置：`## Communication` 与 `## Lead` 之间，作为新的顶层段。
+
+```markdown
+## Worktree Filesystem Access
+
+Worktrees share `.git` but have isolated working trees. **`.gitignored` artifacts do not propagate across worktrees**:
+- `node_modules/` / `dist/` / build caches
+- Manually cloned reference repos (e.g. `docs/research/reference-repos/<repo>/`)
+- Local secrets / configs (`.env`, `.claude/`, etc.)
+
+When an agent working inside a worktree needs these resources:
+
+| Operation | Path |
+|---|---|
+| **Read** main repo's `.gitignored` resources | `$ORCA_ROOT/<path>` (main repo absolute path, env already set) |
+| **Write** task code | current worktree (`pwd`) |
+| **Write** cross-task shared research / reference data | `$ORCA_ROOT/<path>`, must be explicitly stated in the task |
+
+Do not re-install / re-clone / re-build resources that already exist in the main repo — wastes time and disk, and risks divergence from main repo state.
+```
+
+**起源**：与 Tier 1 无关。来自 worker 在 worktree 内重新 clone 资源的实际事故，抽象为一条 skill 层面的通用约束。
+
+### 实施 PR 的范围（独立）
+
+- [ ] 将规则 1 应用到 `skills/orca/SKILL.md`
+- [ ] 将规则 2 应用到 `skills/orca/SKILL.md`
+- [ ] Smoke test：派一个会触发多行汇报的 worker，验证 `/tmp/orca-msg-*` 流程
+- [ ] Smoke test：派一个进入 worktree 后需要读取主仓 `node_modules` 或参考 clone 的 worker，验证 `$ORCA_ROOT` 访问可用
+
 ## P1: Workflow Skills
 
 Light core skill + moderate workflow skills (D4).

--- a/docs/proposals/mixed.md
+++ b/docs/proposals/mixed.md
@@ -1,0 +1,380 @@
+# Mixed Proposals (临时草稿)
+
+聚集多个未实施的提案 / 想法，方便对话之间持久化。条目稳定后再决定拆成独立 design doc 或并入 ARCHITECTURE.md。
+
+---
+
+## 总览
+
+| # | 标题 | 分类 | 状态 | 优先级 | 触发频率 |
+|---|---|---|---|---|---|
+| 1 | tmux-bridge message 引号被吃 | A 通信 | 方案 A/B 暂存为 fallback；新主线 Tier 1 (paste-buffer)，见 PLAN | **P0** | 高，反复触发 |
+| 2 | PreToolUse hook 给 tmux-bridge 放行 | B 权限 | Tier 1 后预期消失（命令体不再含 $(...)），待 Tier 1 验证后再评估 | P1 | 高 |
+| 3 | PreToolUse hook 给只读命令 simple_expansion 放行 | B 权限 | 待决策 | P1 | 中 |
+| 4 | tmux copy mode 软折行 / mouse bypass | C 终端 | 调研完成 | P2 | 中 |
+| 5 | Zed 终端 link 点击需 shift+cmd | C 终端 | 待决策 | P3 | 低 |
+
+### 分类
+
+- **A 通信**：跨 pane / shell 解析阶段的消息内容传递问题
+- **B 权限**：Claude Code permission matcher 对 shell expansion 一刀切降级，hook 兜底放行
+- **C 终端**：终端 app / tmux 层交互体验
+
+### 优先级判定
+
+- **P0**：反复触发，软约束失败已验证 → 需硬性兜底
+- **P1**：高频体验痛点，方案明确，等落地决策
+- **P2**：零成本可加，适配性广
+- **P3**：偏个人配置 / 终端层固有限制，文档化即可
+
+---
+
+## 1. tmux-bridge message 引号被吃
+
+**分类**：A 通信。**状态**：方案 A 已落地（skill 文档约束单引号，仅适用单行），方案 B（多行落盘传递）待推进。**优先级 P0**。
+
+### 2026-04-20 重新评估（新主线：Tier 1 paste-buffer）
+
+参考 `docs/research/stably-orca-compare.md` 对 stablyai/orca 的架构对比（第 4 条启发：减少把结构化控制塞入 shell 命令参数），本提案方向重定向：
+
+- **新主线**：tmux `load-buffer + paste-buffer` 通信改造（Tier 1），完全绕开 bash 解析阶段。详见 `PLAN.md` 中「通信层重构（Tier 1：paste-buffer）」章节
+- **方案 A（单引号约束）**：保留为 fallback，仅作为单行短消息的轻量路径
+- **方案 B（落盘 + 路径传递）**：保留为 debug / 跨 worker 复用场景的 fallback，不再作为多行消息的默认路径
+- 原 P0 优先级保留，但实施路径切换到 Tier 1
+
+### 现象
+
+worker 通过 `tmux-bridge message` 给 lead 发评估时，消息体里包含 `` `auth:session:<token>` `` 这种 Markdown 行内代码片段，lead 收到的内容里反引号片段整段缺失，关键 key 名丢失，导致评估信息失真。
+
+**复现记录**：
+
+- 2026-04-18：worker 评估 auth 改造方案时首次发现，含 `` `auth:session:<token>` ``、`xdclaw_session`、`xdclaw.auth` 等多个 key 名缺失
+- 2026-04-19：worker 发文档大纲预案时再次触发，主体内容到达但「有几处被吃掉」，worker 自己已意识到并主动澄清
+- 2026-04-20：worker 长汇报场景再次触发，第一条带反引号被吃；worker 立即用单引号重发，结果消息体里写的 `\n` 在单引号下成了**字面 2 字符**，lead 收到的是断行被破坏的一长段。**单引号方案的副作用首次暴露**
+
+**结论**：方案 A（软约束）经过 3 次实战验证，不可靠。worker 在 markdown 习惯下仍会写反引号；即使按规则用单引号，多行汇报场景下又踩 `\n` 字面量陷阱。
+
+### 根因
+
+`tmux-bridge` 自身没问题——`/Users/fmfsaisai/.smux/bin/tmux-bridge:250` 用 `tmx send-keys -t "$target" -l -- "${header} $2"`，`-l --` 是字面量模式。
+
+问题在 **调用侧的 bash 解析阶段**：worker 按习惯写
+
+```bash
+tmux-bridge message "$ORCA_PEER" "...`auth:session:<token>`..."
+```
+
+整条 message 体被双引号包裹，bash 在调用 tmux-bridge **之前** 就把反引号里的内容当命令替换执行，结果替换为空。tmux-bridge 拿到的 `$2` 已经是缺字版本。
+
+最小复现：
+
+```bash
+bash -lc 'printf "<%s>\n" "left `auth:session:<token>` right"'
+# command substitution syntax error → 输出 "<left  right>"
+```
+
+风险字符范围：
+
+- 必规避：`` ` ``、`$(...)`、`$var` —— 双引号内一律解释
+- 反斜杠 `\` 参与转义，需注意
+- `!`：仅在开启 histexpand 的 **交互 shell** 风险，当前 worker（codex / claude code 的非交互 bash 路径）不触发
+
+### 方案
+
+#### 方案 A（已落地）：skill 提示词约束 message 体用单引号
+
+`skills/orca/SKILL.md` 通信规则：消息体用单引号 `'...'`，target 部分仍可用 `"$ORCA_PEER"`。
+
+```bash
+tmux-bridge message "$ORCA_PEER" '消息体可以放 `反引号` 和 $变量'
+```
+
+**已暴露副作用**：
+1. 消息体含单引号字符需手动 `'\''` 转义，写起来很丑
+2. **`\n` 不展开成换行**，是字面 2 字符 → 多行汇报破相（2026-04-20 实测）
+3. 软约束不可靠，依赖 worker 习惯
+
+#### 方案 B（推荐落地）：消息体多行 → 落盘传递（复用 PR #8 handoff 模式）
+
+PR #8 已验证 dispatch 方向的 handoff：lead 写 plan 到 `/tmp/orca-handoff-<slug>-<ts>.md`，message 体只放路径。本方案对称扩展到 worker → lead 的汇报方向：
+
+```bash
+msg_path="/tmp/orca-msg-<slug>-$(date +%s).md"
+cat > "$msg_path" <<'EOF'
+长汇报内容，可含 `反引号`、$VAR、'单引号'、真换行
+EOF
+tmux-bridge message "$ORCA_PEER" "Read $msg_path"
+```
+
+新规则：
+- **单行短消息** → 单引号 `'...'`，沿用方案 A
+- **多行 / 含 markdown 代码片段 / 含 shell 元字符** → 落盘 + 路径
+
+收益（相比原 heredoc 方案）：
+- 不改 tmux-bridge
+- 多 worker 广播天然复用同一文件路径
+- `&&` 链兼容（落盘是独立命令，message 仍单行）
+- 不需要嵌套 heredoc 分隔符约定
+- 复用 PR #8 已验证的 CC matcher 行为，无未知风险
+- skill 文档改动最小：扩展现有 handoff 规则到汇报方向
+
+代价：worker / lead 多一步 `cat > ... <<EOF`，临时文件复用 PR #8 sweep 机制（`/tmp` 自动清理）。
+
+### 待办（P0）
+
+1. `skills/orca/SKILL.md` 通信规则补「多行汇报必须落盘 + 路径传递」，规则与 PR #8 dispatch handoff 对称
+2. 复用 PR #8 的 `/tmp` 清理机制，sweep pattern 加 `orca-msg-*`
+3. 给 worker 一次广播：新规则生效
+
+### 决策点
+
+1. 文件路径前缀：`orca-msg-` （汇报方向）vs PR #8 的 `orca-handoff-` （dispatch 方向）。倾向**区分**——便于排查方向，sweep 模式都覆盖
+2. 单行 vs 多行的判定：留给 worker 自觉，还是设字符数阈值（如 >300 字符）？倾向**自觉**——含反引号 / `$` / 多行就落盘，规则简单
+
+### 关联
+
+- 与 PR #8 handoff 模式同源，文档可交叉引用（dispatch 方向 + 汇报方向 = 完整对称）
+- 与 #2 / #3 互补：本条解决"消息内容传递"，#2 / #3 解决"hook 放行"
+- 方案 A 仍适用于单行短消息，B 是多行场景的必选项
+
+---
+
+## 2. PreToolUse hook 给 tmux-bridge 自动放行
+
+**分类**：B 权限。**状态**：待决策（倾向落地）。**优先级 P1**。
+
+### Tier 1 影响（待 Tier 1 验证后再评估）
+
+Tier 1 (paste-buffer) 完成后，`tmux-bridge` 命令体不再包含 `$(...)` 命令替换（内容通过 buffer 而非命令参数传递）。预期效果：
+
+- Claude Code permission matcher 不再因 `$(...)` 触发降级 → 本提案的 ask-prompt 现象大概率自动消失
+- 若验证后确实消失，本提案可降级为 P3 或并入 #3（共同根因仍是 matcher 对 shell expansion 的保守降级）
+- 若 Tier 1 后仍有残留场景，再评估是否单独落地 PreToolUse hook
+
+### 现象
+
+Claude Code 里把 `Bash(tmux-bridge *)` 加进 settings.json allow 列表后，下面这种命令仍然每次弹权限询问：
+
+```bash
+tmux-bridge read $ORCA_PEER 5 && tmux-bridge message $ORCA_PEER "$(cat <<'EOF'
+多行内容
+EOF
+)"
+```
+
+### 根因
+
+**Claude Code 的 permission matcher 对含 `$(...)` 的整条命令保守降级到询问** —— 子 shell 输出动态、无法静态判断会运行什么，所以无论外层 `tmux-bridge *` 是否在 allow 列表都会问。`&&` 链和 `$ORCA_PEER` 变量本身不影响匹配，只有命令替换 `$(...)` 是触发器。
+
+### 排除的方案
+
+| 方案 | 排除理由 |
+|---|---|
+| 改 Claude Code permission matcher 不对 `$(...)` 降级 | 不在我们控制范围 |
+| tmux-bridge 加 `--stdin` (proposal #1B) | 仍要 AI 主动选这种调用形式，没解决"约束 AI"的根本问题 |
+| 包装脚本 / 重命名 | matcher 按整条命令文本看，加包装不影响 `$(...)` 判定 |
+| 改 skill 提示词约束 AI 用单引号 (proposal #1A) | 软约束、概率性，AI 写命令的姿势难以保证 |
+
+### 方案
+
+`~/.claude/settings.json` PreToolUse hook，命令以 `tmux-bridge` 开头就直接放行：
+
+```json
+"PreToolUse": [
+  {
+    "matcher": "Bash",
+    "hooks": [
+      {
+        "type": "command",
+        "command": "jq -r '.tool_input.command' | grep -qE '^[[:space:]]*tmux-bridge[[:space:]]' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\"}}' || exit 0"
+      }
+    ]
+  }
+]
+```
+
+逻辑：命令以 `tmux-bridge` 开头 → harness 层强制 allow；否则不干预走原本 allow/deny。`deny` 列表（如 `rm -rf *`）优先级高于 hook approve，安全红线不破。
+
+### 决策点
+
+1. **是否纳入 orca install.sh 自动注册？**
+   - 倾向是。orca 已经在 `install.sh:108-157` 管理 SessionStart hook，`install_or_update_hook` 在 PR #8 follow-up 里会通用化（P0-3 deferred），届时复用即可
+   - 边界：CC 专属（用 `permissionDecision` 格式），但 orca 现有 hook 也都是 CC 专属——"model-agnostic"在 orca 语境里指**编排逻辑**，不含 harness 集成层
+2. **装载作用域：全局 `~/.claude/settings.json`**（已定）
+   - 项目级方案被否：worker 启动时 cwd 是 worktree 或别的项目，CC 按 cwd 向上查找 settings，跨项目派 worker 时 orca 项目级 settings 找不到
+   - over-reach 风险用 install.sh 显式确认提示兜底（"将修改 ~/.claude/settings.json，确认？"）
+3. **匹配范围**：只放 `tmux-bridge` 还是把 `orca`、`orca-worktree` 也加进去？倾向只放 `tmux-bridge` —— 其他命令副作用面更大，少弹一次询问换不来风险
+
+### 待办
+
+1. P0-3 通用化 `install_or_update_hook` 后接入 PreToolUse hook 注册
+2. `install.sh` 安装 `hooks/allow-tmux-bridge.sh` 脚本（jq + grep 那段）
+3. **前置验证**（落地前必做）：
+   - `command -v jq >/dev/null` 检测 jq 依赖，缺失则报错并提示安装方式
+   - 用 `rm -rf /tmp/orca-deny-test` 实测 CC `deny` 列表与 hook approve 的优先级，确认 deny 优先（文档说法，未实测）
+
+### 关联
+
+- 与 #1 互补：#1 减少触发概率（消息内容侧），#2 兜底覆盖 AI 没遵守约束或 heredoc 必须场景
+- 与 #3 同类：根因同（matcher 对 shell expansion 降级）、方案同（PreToolUse force allow），脚本可合并参数化
+
+---
+
+## 3. PreToolUse hook 给只读命令的 simple_expansion 放行
+
+**分类**：B 权限。**状态**：待决策。**优先级 P1**。
+
+### 现象
+
+带 `$VAR` 变量展开的纯只读命令仍每次弹询问，即使命令本身已在 allow 列表：
+
+```bash
+echo "ROLE=$ORCA_ROLE PEER=$ORCA_PEER WORKERS=$ORCA_WORKERS"
+```
+
+`~/.claude/settings.json` 已加 `Bash(echo:*)`，弹窗仍出现，提示信息：`Contains simple_expansion`。
+
+### 根因
+
+Claude Code permission matcher 对含 shell expansion 的命令统一降级到 ask，触发器包括：
+
+- `$VAR` / `${VAR}` 变量展开（本条主因）
+- `$(...)` 命令替换（proposal #2 主因）
+- 反引号 `` `...` ``
+
+设计意图是防 `echo $(rm -rf /)` 之类绕过 allowlist 的注入。代价是纯只读命令也被一刀切。
+
+### 方案
+
+复用 proposal #2 的 PreToolUse hook 路子，把匹配集合从单一 `tmux-bridge` 扩成可配前缀列表：
+
+```bash
+^[[:space:]]*(echo|env|printf)[[:space:]]
+```
+
+只覆盖明确无副作用的命令。**不放** `cat` / `ls` —— 路径含 `$HOME` 等仍可能触达敏感目录，保留人类确认有意义。
+
+### 决策点
+
+1. 放行集合范围：`echo` / `env` / `printf` 三个够不够？要不要加 `pwd`、`date`？倾向先三个，按需扩
+2. 与 #2 共用脚本还是独立？倾向共用，参数化前缀列表
+3. 装载作用域：跟随 #2，**全局 `~/.claude/settings.json`** + install.sh 显式确认
+4. 是否纳入 install.sh 自动注册（同 #2）？依赖 #2 决策
+
+### 待办
+
+1. 手动在 `~/.claude/settings.json` 试装 hook 验证有效
+2. 确认有效后合并 #2 的 hook 脚本基础设施（共用 jq 依赖检测 + deny 优先级实测）
+
+### 关联
+
+- 与 #2 同类：根因 + 方案 + 脚本基础设施可共享。#2 聚焦 `tmux-bridge` + `$(...)` 命令替换；#3 聚焦只读命令 + `$VAR` 变量展开
+
+---
+
+## 4. tmux copy mode 软折行 / mouse bypass
+
+**分类**：C 终端。**状态**：调研完成，待决策落地兜底方案。**优先级 P2**。
+
+### 现象
+
+orca 内 tmux copy mode 复制出来的文本被预期外的换行切断，无法获得"原生终端复制"的效果。
+
+### 根因
+
+tmux pane 内部按"终端宽度"存储字符网格，程序输出超过宽度时 tmux 自己折行，把一段长文本拆成多行存进 buffer。copy mode 选择 buffer 内容，**软折行**（terminal wrap）和**硬换行**（程序输出 `\n`）出来都是 `\n`，无法区分。
+
+### tmux mouse 模式的硬限制
+
+之前讨论中曾设想"mouse 改成只能滚动，不触发 copy mode" —— 这条路走不通。
+
+tmux mouse 模式在协议层是**二元的**：`set -g mouse on` 就让终端订阅所有 mouse event 给 tmux。unbind 某个 binding（如 `unbind -n MouseDrag1Pane`）只是让 tmux 收到事件后 no-op，**事件仍被 tmux 吃掉，不会穿透到终端原生选择**。所以"部分 mouse 能力"在 tmux 配置层无法实现。
+
+### 终端层 bypass 调研
+
+不同终端 bypass key 不同：
+
+| 终端 | Bypass key | 备注 |
+|---|---|---|
+| iTerm2 | ⌥ Option | 默认 |
+| **Ghostty** | **Shift** | `mouse-shift-capture = false`（默认） |
+| **Zed terminal** | Cmd（实测）/ Shift（理论） | 基于 `alacritty_terminal` |
+| WezTerm | Shift | |
+| macOS Terminal.app | Fn | |
+| Kitty | Shift | `terminal_select_modifiers shift` |
+
+### 各终端实际表现（用户实测）
+
+- **Ghostty + Shift+drag**：bypass 生效，**但跨 pane 选中** —— 终端不知道 pane 存在，把整个窗口当一块字符网格。架构必然，无解
+- **Zed + Shift**：无反应。**Cmd 有反应但仍带换行** —— Zed 用的 `alacritty_terminal` 不追踪 wrap 状态，bypass 也救不了软折行问题
+- iTerm2 / macOS Terminal / Ghostty 都追踪 wrap 状态，原生选择是干净一行；alacritty 系不追踪
+
+### 可行兜底
+
+**方案 A：Ghostty + zoom + Shift+drag**
+
+要复制时 `prefix+z` zoom 当前 pane 全屏 → Shift+drag → `prefix+z` 取消 zoom。zoom 状态下 window 只剩一个 pane，跨不了。两步操作但比 copy mode 换行问题省心。
+
+**方案 B（推荐落地到 orca）：`prefix+P` 一键 capture-pane 到剪贴板**
+
+在 `start.sh` 里追加 binding：
+
+```bash
+$TMUX_CMD set-option -t "$SESSION" -g \
+  bind-key P run-shell "tmux capture-pane -J -p -S -3000 | pbcopy && tmux display 'pane copied'"
+```
+
+`-J` 让 tmux 把 wrapped lines join 回去 —— 这是 tmux 自己的"知道 wrap"接口，比 copy mode 的"二进制 buffer dump"高级。失去交互式选区，但作为"AI 给的长输出我要整段"的 fallback 很顺手。Ghostty / Zed / 任何终端都能用。
+
+**Zed 用户专属现实**：Zed 的内置终端因为 alacritty_terminal 不追踪 wrap，**没法做到完美原生复制**。重要复制操作建议搬到 Ghostty 或 iTerm2 做；Zed 终端用来跑 dev server / 看日志够了。
+
+### 决策点
+
+1. **是否把方案 B（`bind P`）加到 `start.sh`？** 倾向加 —— 零成本，普适，不影响现有交互
+2. **是否文档化"Zed 终端不适合 orca host"？** 倾向加一句到 README 或 docs，避免用户重复踩坑
+
+### 待办
+
+1. `start.sh` 追加 `bind-key P` capture-pane 配置
+2. （可选）docs 加"推荐终端"段，标注 Ghostty / iTerm2 ✅，Zed 终端 ⚠️ 软折行无解
+3. （可选）`pbcopy` 是 macOS 专属，跨平台版本用 `command -v pbcopy >/dev/null && pbcopy || (command -v wl-copy >/dev/null && wl-copy || xclip -selection clipboard)` 之类
+
+### 关联
+
+- 与 #5 同类（C 终端）：都是 Zed 终端的特殊行为，可在「推荐终端」文档段统一说明
+
+---
+
+## 5. Zed 终端 link 点击需 shift+cmd
+
+**分类**：C 终端。**状态**：待决策（仅文档化）。**优先级 P3**。
+
+### 现象
+
+Zed 内置终端里，AI 输出的 URL / 文件路径链接需要 **shift+cmd+click** 才能打开，而非常见的 cmd+click 或单击。
+
+iTerm2 / Ghostty 等终端默认 cmd+click 即可打开链接，Zed 的修饰键组合不一致导致用户在 orca host 切换终端时手感断层。
+
+### 根因
+
+Zed 终端的 link click 行为绑定 `terminal::OpenLink` action 到 `cmd-shift-click`（推测，待查 keymap 默认值）。这是 Zed 编辑器全局风格："cmd+click 用于 go-to-definition"，终端 link 让位于 shift+cmd。
+
+### 方案
+
+**仅文档化**，不改 Zed 配置：
+
+- 在 docs「推荐终端」段（与 #4 决策 2 合并）注明：Zed 终端 link 点击为 **shift+cmd+click**
+- 不建议为单一终端调 keymap —— 用户偏好差异大，文档说明即可
+
+### 决策点
+
+1. 是否同时给出 Zed keymap 自定义示例？倾向**不给** —— 容易过度配置且与 Zed 升级冲突
+2. 与 #4 的「推荐终端」段合并写还是分开？倾向合并，统一一节列各终端注意点
+
+### 待办
+
+1. （与 #4 决策 2 一起）docs「推荐终端」段加 Zed link 点击说明
+
+### 关联
+
+- 与 #4 同类（C 终端）：Zed 终端使用注意事项可统一说明

--- a/docs/research/stably-orca-compare.md
+++ b/docs/research/stably-orca-compare.md
@@ -1,0 +1,155 @@
+# stablyai/orca — 架构对比研究
+
+## Provenance
+
+- Source repository: https://github.com/stablyai/orca
+- Reviewed commit: c47b651f2d7e79c5ca22737334495a953a9c2c11 (tag 1.3.6, 2026-04-19)
+- Upstream license: MIT (Copyright © 2026 Lovecast Inc.)
+- Reviewed: 2026-04-20
+- Method: 仅静态阅读源码，无代码执行
+- Scope: 编排 runtime、IPC、agent 通信、worktree 处理、状态检测。UI / build / i18n 不在范围
+- Attribution form: 仅以「文件路径 + 行号」形式引用（如 `src/main/runtime/orca-runtime.ts:138-198`），未复制任何源码
+
+---
+
+## 1. 编排机制
+
+`stablyai/orca` 的核心实现不是 lead/worker 式的文本协作器，而是 Electron main process 内的长期存活 runtime control plane。
+
+- 主入口位于 `src/main/index.ts:140-226`。`app.whenReady()` 中初始化 `OrcaRuntimeService`、`registerCoreHandlers()`、`OrcaRuntimeRpcServer`，随后打开主窗口。由此可见，编排核心位于 main process，而不是 renderer 或 shell wrapper。
+- 运行时核心位于 `src/main/runtime/orca-runtime.ts:138-198`。`OrcaRuntimeService` 内部维护 `tabs`、`leaves`、`handles`、`waiters`，将每个 terminal pane/leaf 视为可寻址对象，而不是将 agent 建模为互发消息的角色。
+- 多 agent 组织方式体现为“单个 workspace 下的多个 tab/group/leaf”：
+  - 持久化 schema 位于 `src/shared/workspace-session-schema.ts:177-191`，包含 `tabsByWorktree`、`terminalLayoutsByTabId`、`unifiedTabs`、`tabGroups`、`tabGroupLayouts`。
+  - live graph 同步位于 `src/main/runtime/orca-runtime.ts:198-230`，renderer 将 graph 同步给 main，随后由 main 维护 authoritative terminal state。
+- 进程形态如下：
+  - 本地 terminal 通过 `node-pty` 驱动，见 `src/main/providers/local-pty-provider.ts:7,112-176,318-325`。
+  - 远程 terminal 通过 SSH provider 抽象驱动，见 `src/main/providers/types.ts:53-67`、`src/main/providers/ssh-pty-provider.ts:66-88,133`。
+  - 另有可选的 daemon-backed persistent terminal provider，并未观察到 Docker/container 编排路径，启动分支位于 `src/main/index.ts:185-209,191-201`。
+
+从结构上看，`stablyai/orca` 的多 agent 编排更接近“桌面端多终端/多工作区控制平面”，而不是基于 tmux pane 的显式角色调度。
+
+## 2. Agent 通信
+
+### 2.1 main ⇄ renderer / CLI 通信
+
+- renderer 与 main 之间通过 Electron IPC 通信，核心注册入口位于 `src/main/ipc/register-core-handlers.ts:37-83`。
+- terminal 数据不是以文件或 message 文本形式传递，而是 PTY 数据流直通：
+  - `src/main/ipc/pty.ts:196-240` 维护 `pendingData`，按 8ms flush，并通过 `mainWindow.webContents.send('pty:data', ...)` 推送给 renderer；进程退出时发送 `pty:exit`。
+- CLI 对运行时的控制不是 stdin/stdout 转发，而是本地 RPC：
+  - `src/main/runtime/runtime-rpc.ts:50-156` 启动本地 socket server，并生成随机 `authToken`。
+  - bootstrap 元数据写入 `orca-runtime.json`，字段包含 `transport` 和 `authToken`，见 `src/shared/runtime-bootstrap.ts:13-24`、`src/main/runtime/runtime-metadata.ts:16-46`。
+  - RPC 方法采用资源式接口，而不是 peer message，包括 `status.get`、`terminal.list/show/read/send/wait`、`worktree.ps/list/create`，见 `src/main/runtime/runtime-rpc.ts:218-385,524-573`。
+
+### 2.2 agent ⇄ agent 关系
+
+在本次聚焦的 core 文件范围内，未观察到与 `lead -> worker` 对应的显式角色关系层。以下结论属于基于源码结构的推断：
+
+- runtime API 面向 terminal/worktree handle，而不是 peer label 或 role，见 `src/main/runtime/runtime-rpc.ts:229-342` 与 `src/main/runtime/orca-runtime.ts:290-375`。
+- `OrcaRuntimeService` 维护的是 terminal handle、leaf、waiter，并未维护“谁向谁派发任务”的关系，见 `src/main/runtime/orca-runtime.ts:145-181`。
+
+基于上述结构，`stablyai/orca` 的协作模型更接近“多个平铺 agent terminal 由 UI 与 runtime 统一观察和控制”，而不是显式的 lead/worker 层级调度。
+
+### 2.3 长消息 / 多行内容
+
+本次阅读范围内未发现与 `/tmp/orca-handoff-*.md` 或 `/tmp/orca-msg-*.md` 对应的 handoff 文件机制。原因可从接口形态解释：
+
+- 控制接口采用结构化 RPC 与 PTY 字节流，不需要将长消息拼装为 shell 命令参数。
+- 用户观察对话主要通过 UI 中的 terminal 内容与持久化 session：
+  - terminal 流由 `pty:data` 推送，见 `src/main/ipc/pty.ts:206-240`
+  - workspace session 持久化由 `session:get/set/set-sync` 完成，并包含 scrollback buffer，见 `src/main/ipc/session.ts:6-18`
+
+这一实现路径绕开了 shell quoting、反引号替换与多行参数传递等问题。
+
+## 3. Worktree / 仓库隔离
+
+- `stablyai/orca` 直接内建 git worktree 能力，而不是通过额外 shell script 封装：
+  - git worktree 基础操作位于 `src/main/git/worktree.ts:30-81,94-191`
+  - IPC 暴露位于 `src/main/ipc/worktrees.ts:35-140`
+  - 路径、branch 计算与安全校验位于 `src/main/ipc/worktree-logic.ts:8-40,47-94,96-121`
+- 关键特征如下：
+  - 支持本地 repo、folder-mode、SSH remote repo 三种路径，见 `src/main/ipc/worktrees.ts:49-107,120-135`
+  - worktree path 会进行 workspace 目录约束，用于防止 path traversal，见 `src/main/ipc/worktree-logic.ts:32-44`
+  - 支持 Windows/WSL 路径归一化与跨平台比较，见 `src/main/git/worktree.ts:9-27`、`src/main/ipc/worktree-logic.ts:68-94,96-112`
+  - 删除 worktree 后会执行 prune，并尝试删除本地 branch，见 `src/main/git/worktree.ts:165-210`
+
+与此对照，`fmfsaisai/orca` 当前的 worktree 管理主要由 `orca-worktree.sh:8-39,51-57` 完成，直接执行 `git worktree add/remove` 并将目录落在 `.orca/worktree/<id>/`。
+
+## 4. Idle / 状态检测
+
+`stablyai/orca` 的状态检测主要依赖直接监听 PTY 输出与 terminal title，而不是通过 hook 文件观察工具调用。
+
+- 状态识别规则位于 `src/shared/agent-detection.ts:10-19,31,120-150,271-320`
+  - 可识别 `claude`、`codex`、`gemini`、`opencode`、`aider`
+  - 可从 OSC title 提取 `working | permission | idle`
+- main process 中的 `AgentDetector` 位于 `src/main/stats/agent-detector.ts:60-140`
+  - 每次 `onData()` 直接扫描 raw PTY data
+  - 通过 `extractLastOscTitle()` 与 `detectAgentStatusFromTitle()` 判断状态
+  - 区分 “meaningful output” 与纯 ANSI 噪音，以减少 idle prompt 被误判为 working 的情况
+- `StatsCollector` 位于 `src/main/stats/collector.ts:53-149`，负责统计 agent start/stop 与累计时长
+- 整体链路可概括为 `PTY output -> AgentDetector -> StatsCollector`，而不是 `tool hook -> heartbeat file`
+
+与此对照，`fmfsaisai/orca` 当前的 idle 检测来自 hook 文件：
+
+- worker 侧 PostToolUse 写 heartbeat，见 `hooks/post-tool-use.sh:2-8`
+- lead 侧 PreToolUse 读取 heartbeat，并在 30s 阈值上输出 `[orca] Idle: ...`，见 `hooks/check-heartbeat.sh:2-29`
+- 设计说明位于 `docs/design/heartbeat.md:21-26,52-60`
+
+两种方案的观察对象不同：前者更接近 terminal/agent runtime 状态，后者更接近工具调用活跃度。
+
+## 5. 关键文件清单
+
+- 主入口 / 编排装配：
+  - `src/main/index.ts:86-226`
+  - `src/main/ipc/register-core-handlers.ts:37-83`
+- runtime 控制平面：
+  - `src/main/runtime/orca-runtime.ts:138-198,290-375`
+  - `src/main/runtime/runtime-rpc.ts:50-156,218-385,524-573`
+  - `src/shared/runtime-bootstrap.ts:13-24`
+  - `src/main/runtime/runtime-metadata.ts:16-46`
+- PTY / 子进程管理：
+  - `src/main/ipc/pty.ts:19-25,125-182,196-240,300-359`
+  - `src/main/providers/types.ts:10-67`
+  - `src/main/providers/local-pty-provider.ts:7,112-176,318-325,415`
+- worktree：
+  - `src/main/git/worktree.ts:30-81,94-191`
+  - `src/main/ipc/worktrees.ts:35-140`
+  - `src/main/ipc/worktree-logic.ts:8-44,47-121`
+- 状态检测：
+  - `src/shared/agent-detection.ts:31,120-150,271-320`
+  - `src/main/stats/agent-detector.ts:60-140`
+  - `src/main/stats/collector.ts:53-149`
+
+## 对 fmfsaisai/orca 的启发（项目方解读）
+
+### stablyai/orca 在相关方面的覆盖
+
+- 通信层避免了 shell quoting 问题，控制命令通过 RPC 发出，内容展示通过 PTY 流完成。
+- runtime 由 main process 持有 authoritative state，terminal handle 稳定，因此能够提供 `list/show/read/send/wait` 这类统一编排接口。
+- worktree 是一等公民能力，而不是附属脚本；本地、SSH、WSL、Windows 路径差异均在同一套抽象内处理。
+- 状态检测直接观察 terminal/agent 生命周期，而不是通过工具调用频率间接推断。
+
+### fmfsaisai/orca 在相关方面的特点
+
+- 架构较为精简，部署路径集中于 shell、tmux 与 skill 协作。
+- lead/worker 分工明确，适合通过主代理拆分任务给多个子代理的工作流。
+- 临时 worktree、handoff 文件与 tmux pane 均可由维护者直接人工介入，排障路径较短。
+
+### 可借鉴方向
+
+1. 将“编排接口”从 `tmux-bridge message + pane label` 逐步提升为稳定句柄与结构化命令接口。
+   `stablyai/orca` 中 `terminal.list/show/read/send/wait` 这类 runtime API 形态，为接口演化提供了一个可参考样本。
+2. 将“终端状态”与“调度状态”分离。
+   `fmfsaisai/orca` 当前 heartbeat 主要反映工具活跃度；若引入 terminal-title 或 stdout pattern 检测层，可形成另一条独立观察面。
+3. 将 worktree 逻辑从 shell script 提升到库级模块。
+   `stablyai/orca` 中的路径规范化、删除后 prune 与 branch cleanup、错误分类处理，展示了更完整的 worktree 生命周期治理方式。
+4. 减少“将结构化控制内容塞入 shell 命令参数”的场景。
+   `stablyai/orca` 采用 RPC 与 PTY 流后，长消息、特殊字符与多行内容不再依赖 shell 参数传递。
+
+### 不直接适用的部分
+
+- Electron main/renderer/runtime-rpc 的整套控制平面较重，与 `fmfsaisai/orca` 当前的 shell + skills 产品形态并不等价。
+- `stablyai/orca` 的平铺 terminal 模型，并不直接对应 `fmfsaisai/orca` 的 lead/worker 编排模型；二者面向的协作体验不同。
+
+## 总结
+
+`stablyai/orca` 主要解决的是“桌面应用如何统一托管与观察多个 agent terminal”；`fmfsaisai/orca` 当前主要解决的是“在 shell/tmux 环境中由 lead 协调多个 worker”。前者在 runtime、通信与 worktree 抽象上的覆盖范围更广，后者在角色编排、轻量部署与人工介入路径上具有不同特点。两者差异的核心不在界面形态，而在编排控制面的建模方式。


### PR DESCRIPTION
## 核心结论

`tmux-bridge` 反复触发 quoting 失败（反引号被吃、`$VAR` 触发权限询问、多行 heredoc 破相）的**根因不是 shell 写法**，而是架构选择：「把结构化指令拼成 shell 命令参数」。这条参数路径必经 bash 解析，反引号、`$()`、`$VAR` 永远会按 shell 语义先被处理。

研究 stablyai/orca（Electron 桌面 app，MIT 协议，[c47b651f](https://github.com/stablyai/orca/tree/c47b651f)）后发现，他们的解法是结构化 RPC + PTY 字节流直通，让 shell 完全退出通信链路。这个思路对我们成立，**但实现路径不学**——他们是 GUI 产品，我们是 shell-native，没必要起 Electron。

## 新主线：Tier 1（paste-buffer）

借鉴思路、保留形态：用 tmux 自带的 `load-buffer + paste-buffer` 把消息体从 shell 参数搬到 tmux buffer。bash 不再解析消息内容。

```
tmx load-buffer -b <name> <path>      # 文件 → buffer，无 bash
tmx paste-buffer -t <target> -b <name> # buffer → pane，无 bash
```

零新依赖、零产品形态变更，预期一并解决 mixed.md #1（quoting）和 #2（`$()` 权限询问）。详见 PLAN.md。

## 为什么这是规划 PR 而非实施

Tier 1 真正落地需要：
- 改 `tmux-bridge` 加 `message-file` 子命令
- Smoke test bracketed paste 在 Claude Code / Codex 的实际行为
- 同步改 `skills/orca/SKILL.md` 通信规则

任意一步出问题都会影响 worker 行为。本 PR 故意只做研究归档 + 路线确定，不动 `skills/`、不动 `tmux-bridge`，避免研究决策与实施验证混在一个 PR 里。

PLAN.md 新增「待落地的 Skill 规则」章节里**完整保存**了过渡期 fallback 规则（落盘传递）和 worktree 文件系统访问约定的写法，留给实施 PR 直接搬。

## mixed.md 各项状态

本 PR 只重塑 #1 / #2（与通信架构同源），其他项保持现状：

| # | 提案 | 本 PR 处理 |
|---|---|---|
| #1 | tmux-bridge message 引号被吃（P0） | **新主线 Tier 1**；原方案 A/B 降级为 fallback |
| #2 | PreToolUse hook 给 tmux-bridge 放行（P1） | **预期被 Tier 1 顺带解决**（命令体不再含 `$()`），待验证后再决定是否独立落地 |
| #3 | hook 给只读命令 `$VAR` 放行（P1） | 不变。与通信无关，独立议题 |
| #4 | tmux copy mode 软折行（P2） | 不变。终端层议题 |
| #5 | Zed 终端 link 点击需 shift+cmd（P3） | 不变。终端层议题 |

## 改动文件

- `docs/research/stably-orca-compare.md`（新增）—— 完整研究归档，含 provenance（来源、SHA、MIT 归属、范围、引用形式）
- `docs/proposals/mixed.md`（新增 + 修改）—— #1/#2 加重新评估块，原方案保留为 fallback；#3-5 未动
- `PLAN.md`—— 新增 Tier 1 章节 + 待落地 Skill 规则章节

## 不在本 PR 范围

- `skills/orca/SKILL.md` 任何改动（worker 行为不变）
- `tmux-bridge` 实现改动
- Tier 1 子任务实施

## Reviewer 验证提示

```bash
# 确认 SKILL 与 tmux-bridge 未被改动
git diff master..HEAD --stat -- skills/ tmux-bridge

# 确认研究文档无源码复制（应输出 0）
grep -c '^```' docs/research/stably-orca-compare.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
