### PR TITLE
feat: orca-worktree slug naming convention with format validation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -58,8 +58,8 @@ orca --lead claude --worker codex --workers 3 --workflow code
 - [x] `--workflow <name>` — load workflow skill
 
 **Worktree**
-- [x] On-demand `<repo>/.orca/worktree/<id>` at dispatch (D5)
-- [x] `orca-worktree create/remove/list/clean` helper
+- [x] On-demand `<repo>/.orca/worktree/<slug>` at dispatch (D5)
+- [x] `orca-worktree create/remove/list/clean` helper (`<slug>` = kebab-case feature name; append `-<n>` only for same-feature multi-worker splits)
 - [x] stop.sh cleanup
 
 **Hooks** (D1, D3)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ orca --lead claude --worker codex          # explicit models (default)
 orca --worker ./my-agent                   # custom binary as worker
 ```
 
-Workers get isolated git worktrees (`.orca/worktree/<id>`) and heartbeat monitoring.
+Workers get isolated git worktrees (`.orca/worktree/<slug>`) and heartbeat monitoring. Use a kebab-case feature slug such as `auth-refactor`; append `-<n>` only when multiple workers share the same feature.
 
 See [design docs](docs/design/) for architecture details.
 
@@ -59,7 +59,7 @@ See [design docs](docs/design/) for architecture details.
 | `orca rm <name\|id>` | Remove a specific instance (any dir) |
 | `orca prune` | Clean up dead socket inodes |
 | `orca idle -t coder -T 300` | Wait for an agent pane to go idle |
-| `orca-worktree create/remove/list/clean` | Manage worker worktrees |
+| `orca-worktree create/remove/list/clean` | Manage worker worktrees (`<slug>` must be kebab-case) |
 | `tmux-bridge read/message/list` | Cross-pane communication |
 
 ### Start Options

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,7 +44,7 @@ orca --lead claude --worker codex          # 指定模型（默认值）
 orca --worker ./my-agent                   # 自定义 binary 做 worker
 ```
 
-Worker 使用独立 git worktree（`.orca/worktree/<id>`）隔离，心跳机制监控 idle 状态。
+Worker 使用独立 git worktree（`.orca/worktree/<slug>`）隔离，心跳机制监控 idle 状态。`<slug>` 使用 kebab-case feature 名称，例如 `auth-refactor`；只有多个 worker 处理同一 feature 时才追加 `-<n>`。
 
 架构详情见 [design docs](docs/design/)。
 
@@ -58,7 +58,7 @@ Worker 使用独立 git worktree（`.orca/worktree/<id>`）隔离，心跳机制
 | `orca rm <name\|id>` | 移除指定实例（任意目录） |
 | `orca prune` | 清理失效的 socket inode |
 | `orca idle -t coder -T 300` | 等待 agent pane 进入 idle |
-| `orca-worktree create/remove/list/clean` | 管理 worker worktree |
+| `orca-worktree create/remove/list/clean` | 管理 worker worktree（`<slug>` 必须是 kebab-case） |
 | `tmux-bridge read/message/list` | 跨 pane 通信 |
 
 ### 启动选项

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,7 @@
 
 **Heartbeat via hooks** — no background monitor (deferred to P3). Workers write timestamps via PostToolUse hook (`.orca/heartbeat/<id>`). Lead checks heartbeats via PreToolUse hook, outputs `[orca]` notifications inline on next tool use. 30s cooldown per worker. Limitation: notifications only surface when lead is actively using tools.
 
-**On-demand worktrees** — `orca-worktree create/remove/list/clean` at `.orca/worktree/<id>`. Created by lead before dispatch, cleaned by `orca stop`.
+**On-demand worktrees** — `orca-worktree create/remove/list/clean` at `.orca/worktree/<slug>`. Slugs use kebab-case feature names, with optional `-<n>` only for same-feature multi-worker splits. Created by lead before dispatch, cleaned by `orca stop`.
 
 **Handoff files** — long-context dispatch uses `/tmp/orca-handoff-<slug>-<timestamp>.md` instead of inline tmux-bridge messages. Survives truncation, context compaction, and worker restarts.
 

--- a/orca-worktree.sh
+++ b/orca-worktree.sh
@@ -12,18 +12,31 @@ usage() {
 Usage: $(basename "$0") <command> [args]
 
 Commands:
-  create <id>   Create worktree at $ORCA_DIR/<id> on branch orca-<id>
-  remove <id>   Remove worktree and delete branch orca-<id>
-  list          List active orca worktrees
-  clean         Remove all orca worktrees
+  create <slug>   Create worktree at $ORCA_DIR/<slug> on branch orca-<slug>
+  remove <slug>   Remove worktree and delete branch orca-<slug>
+  list            List active orca worktrees
+  clean           Remove all orca worktrees
+
+<slug> rules: kebab-case, 3-40 chars, start with a letter.
+Examples: auth-refactor, fix-login-bug, auth-refactor-1.
 EOF
+}
+
+validate_slug() {
+  local slug="$1"
+  local len=${#slug}
+  if [ "$len" -lt 3 ] || [ "$len" -gt 40 ] || ! [[ "$slug" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
+    echo "Error: invalid slug '$slug'. Must be kebab-case, 3-40 chars, start with a letter. Examples: auth-refactor, fix-login-bug, auth-refactor-1" >&2
+    exit 2
+  fi
 }
 
 cmd="${1:-}"
 
 case "$cmd" in
   create)
-    id="${2:?create requires an <id>}"
+    id="${2:?create requires a <slug>}"
+    validate_slug "$id"
     dir="${ORCA_DIR}/${id}"
     branch="orca-${id}"
     mkdir -p "$(dirname "$dir")"
@@ -32,7 +45,8 @@ case "$cmd" in
     ;;
 
   remove)
-    id="${2:?remove requires an <id>}"
+    id="${2:?remove requires a <slug>}"
+    validate_slug "$id"
     dir="${ORCA_DIR}/${id}"
     branch="orca-${id}"
     git worktree remove "$dir" --force 2>/dev/null || true

--- a/skills/orca/SKILL.md
+++ b/skills/orca/SKILL.md
@@ -47,7 +47,7 @@ Multi-worker: use specific label from `$ORCA_WORKERS` instead of `$ORCA_PEER`.
 2. **Dispatch** — for each worker, send: goal, scope, constraints, worktree path. End with: "Run /review, build, test. Fix issues, then report."
    - Single worker: use `$ORCA_PEER`
    - Multi-worker: iterate `$ORCA_WORKERS` (comma-separated), dispatch to each
-   - Worktree: run `orca-worktree create <id>` first, tell worker to `cd` into it
+   - Worktree: run `orca-worktree create <slug>` first (`<slug>` = kebab-case feature name, e.g. `auth-refactor`; append `-<n>` only when multiple workers share that feature), then tell worker to `cd` into it
    - **Long-context tasks**: write full plan to `/tmp/orca-handoff-<task-slug>-<timestamp>.md` and tell worker to read that path. Survives tmux-bridge truncation and context compaction.
 3. **Wait** — say "dispatched, waiting" and **end turn**. Do not poll.
    - Heartbeat: `[orca]` idle notifications surface on lead's next tool use (PreToolUse hook). For immediate awareness, `tmux-bridge read <worker>` to check pane.


### PR DESCRIPTION
## Summary

- `orca-worktree create/remove <slug>` 加入 slug 格式校验（kebab-case，3-40 字符，必须字母开头），不合法时报错 + 示例提示，exit 2
- 文档/skill 同步从 `<id>` 切换到 `<slug>` 语义

## Why

实战中 worktree 命名完全自由（`task-1` / `worker1` 等无语义），多 worker 并行时难以从目录名识别归属。约束为 kebab-case feature slug 后，目录名即可表达任务语义。

序号不强制：lead 自行决定是否追加 `-<n>`，同 feature 多 worker 时自然产生（如 `auth-refactor-1`、`auth-refactor-2`）。

## Decisions

| 问题 | 决定 |
|---|---|
| slug 谁产出 | lead 显式传入 |
| 序号谁产出 | lead 自决，CLI 不自动加 |
| CLI 形态 | 保持 `create <slug>`，加格式校验 |
| 命名约定 | `<slug>` 全局替换 `<id>` 占位符 |
| 校验范围 | `create` + `remove` 都校验（typo 立刻发现） |
| 正则 | `^[a-z][a-z0-9]*(-[a-z0-9]+)*$`（强制字母开头） |

## 改动统计

6 文件 / +28 / -14

| 文件 | 改动 |
|---|---|
| `orca-worktree.sh` | 加 `validate_slug()`，create/remove 入口校验 |
| `PLAN.md` / `README.md` / `README.zh-CN.md` / `docs/ARCHITECTURE.md` | `<id>` → `<slug>`，附 kebab-case 说明 |
| `skills/orca/SKILL.md` | Lead Dispatch 步骤示例同步 |

`skills/workflows/code/SKILL.md` 内 bash 代码示例保留为抽象 `task-1`（不引入具体业务名）。

## Test plan

- [x] `bash -n orca-worktree.sh` 语法 OK
- [x] 8 个 reject 用例：下划线 / 首位连字符 / 过短 / 双连字符 / 大写 / 过长 / 纯数字 / `remove BAD_ID`
- [x] 2 个 accept 用例：`auth-refactor-1` create + remove
- [x] Reviewer：在干净分支上重跑上述用例
- [x] Reviewer：确认 `git diff master..HEAD --stat` 与上方一致