### PR TITLE
feat: D10 unified message rule + worktree wording

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -62,7 +62,7 @@ orca --lead claude --worker codex --workers 3 --workflow code
 - [x] On-demand `<repo>/.orca/worktree/<slug>` at dispatch (D5)
 - [x] `orca-worktree create/remove/list/clean` helper (`<slug>` = kebab-case feature name; append `-<n>` only for same-feature multi-worker splits)
 - [x] stop.sh cleanup
-- [ ] Smoke test：worker 在 worktree 内读取主仓 `node_modules` / 参考 clone，验证 `$ORCA_ROOT` 访问可用
+- [x] Smoke test：worker 在 worktree 内读取主仓 `.gitignored` 资源（`.claude/settings.local.json`），验证 `$ORCA_ROOT` 访问可用
 
 **Hooks** (D1, D3)
 - [x] `hooks/post-tool-use.sh` — worker heartbeat (PostToolUse)

--- a/PLAN.md
+++ b/PLAN.md
@@ -37,6 +37,7 @@ Known issues:
 | D7 | Multi-instance per dir | TBD — direction: Claude Code resume-style picker (list existing + "new") | Current `orca-<dirname>` collides on re-run; explicit `--name` flag rejected as too manual |
 | D8 | tmux server scope | Per-instance dedicated server via `tmux -L orca-<dirname>` | User's main tmux server caches stale env globally; sharing it pollutes user state. Per-instance server: stop=kill server=clean env, start=fresh fork from current shell. Overhead ~5MB/instance, negligible. See [docs/troubleshooting/tmux-server-stale-env.md](docs/troubleshooting/tmux-server-stale-env.md) |
 | D9 | Lead/worker model selection | `--lead MODEL --worker MODEL` flags + `$ORCA_ROLE` env var | Resolved: role-by-env-var (`$ORCA_ROLE`) decouples role from activation command. Any binary can be lead or worker. `model_cmd()` maps model names to launch commands. See [docs/design/multi-worker.md](docs/design/multi-worker.md). |
+| D10 | Structured content delivery channel | Inline single-quoted `tmux-bridge message` is the default; switch to file on disk (`/tmp/orca-msg-*.md`) only when content contains `'` or newlines | Tested `tmux load-buffer + paste-buffer` (Tier 1) — content reaches worker intact, but Codex multi-line paste needs Enter×2 (timing-sensitive) and full body lands in worker conversation history (compaction risk). Single-quote wrapping makes most short messages safe inline, so the file fallback only triggers on `'` or newlines — narrow scope, low overhead. File delivery (when triggered) keeps worker context lean (path-only message), is auditable, and uses one mental model for all structured content. Smux/`tmux-bridge` source is upstream so no code-level guard is added; rule is enforced by SKILL discipline. |
 
 ## Target Architecture
 
@@ -61,6 +62,7 @@ orca --lead claude --worker codex --workers 3 --workflow code
 - [x] On-demand `<repo>/.orca/worktree/<slug>` at dispatch (D5)
 - [x] `orca-worktree create/remove/list/clean` helper (`<slug>` = kebab-case feature name; append `-<n>` only for same-feature multi-worker splits)
 - [x] stop.sh cleanup
+- [ ] Smoke test：worker 在 worktree 内读取主仓 `node_modules` / 参考 clone，验证 `$ORCA_ROOT` 访问可用
 
 **Hooks** (D1, D3)
 - [x] `hooks/post-tool-use.sh` — worker heartbeat (PostToolUse)
@@ -81,97 +83,6 @@ orca --lead claude --worker codex --workers 3 --workflow code
 - [x] Verify `tmux-bridge` auto-detects via `$TMUX` (zero changes needed; out-of-pane `name` calls pass `TMUX_BRIDGE_SOCKET`)
 - [x] Pre-D8 legacy session cleanup in `stop.sh` (orphan sessions on user's main tmux are detected + removed alongside dedicated)
 - [x] Sanitize `.` and `:` in dir basename (pre-existing bug surfaced during D8 smoke test)
-
-## 通信层重构（Tier 1：paste-buffer）
-
-**起源**：`docs/research/stably-orca-compare.md` 指出，`docs/proposals/mixed.md` 中 #1 和 #2（以及部分 #3）的根因是「将结构化指令塞入 shell 命令参数」。
-
-**目标**：让 `tmux-bridge` 的内容传递路径绕开 bash 解析。
-
-**方案**：将 `send-keys -l` 的内容通道替换为 `tmux load-buffer + paste-buffer`。
-- 新增 `tmux-bridge message-file <target> <path>` 子命令
-- 内部实现：`tmx load-buffer -b <name> <path> && tmx paste-buffer -t <target> -b <name>`
-- 原 `send-keys` 仍用于控制按键（Enter、Esc 等）
-
-**范围**
-- [ ] `tmux-bridge` `message-file` 子命令
-- [ ] Smoke test：Claude Code / Codex 在 bracketed paste 下的行为验证
-- [ ] `skills/orca/SKILL.md` 通信规则更新：结构化内容一律走 `message-file`
-- [ ] `docs/proposals/mixed.md` #1 收尾：方案 A/B 仍作为 fallback，但不再是主线
-
-**不在本范围内**（推迟到 Tier 2/3，详见研究文档）
-- Agent 原生 hook 注入（按 agent 单独适配，脆弱）
-- Sidecar RPC 进程（接近 stably Electron 模式，过重）
-
-**待澄清**
-- 不同 agent 对 bracketed paste 的兼容性
-- buffer 名称管理与清理策略
-
-## 待落地的 Skill 规则（留到独立的实施 PR）
-
-以下规则会直接修改 `skills/orca/SKILL.md`，merge 后立刻改变 worker 行为。本 PR 是研究 + 规划范畴，特意将这些规则拆出来，放到独立 PR 单独 review 与 smoke test。
-
-### 规则 1：Worker → Lead 汇报 fallback（过渡方案，等 Tier 1 落地后被取代）
-
-插入位置：`## Communication` 段的 `Multi-worker:` 行之后。
-
-```markdown
-Worker → Lead reply rules:
-> Current solution. Will be superseded by Tier 1 (paste-buffer) once landed; see `PLAN.md` "通信层重构（Tier 1：paste-buffer）".
-
-- Single-line short message (no backticks, no `$`, no newlines) → keep inline, wrap body in single quotes
-- Multi-line / contains backticks / contains `$` / contains markdown code block / needs cross-worker reuse → write report to `/tmp/orca-msg-<task-slug>-<timestamp>.md`, reuse the dispatch handoff slug, then send only the path
-
-​````bash
-msg_path="/tmp/orca-msg-auth-refactor-$(date +%s).md"
-cat > "$msg_path" <<'EOF'
-Full report body can include `code`, $VARS, 'quotes', and real newlines.
-EOF
-tmux-bridge read "$ORCA_PEER" 5 && tmux-bridge message "$ORCA_PEER" "Read $msg_path" && tmux-bridge read "$ORCA_PEER" 5 && tmux-bridge keys "$ORCA_PEER" Enter
-​````
-```
-
-另外在 `## Lead` 第 2 步「Long-context tasks」那条之后追加：
-
-```markdown
-- Symmetric for worker → lead reports; see Communication > Worker → Lead reply rules.
-```
-
-并在 `## Worker` 第 3 步的 Report 行末尾追加 `(follow Communication rules for inline vs file)`。
-
-**起源**：本 PR 中暴露的漏洞 —— `mixed.md` 宣称落盘是 fallback，但 `SKILL.md` 内并不存在对应的可执行规则。
-
-### 规则 2：Worktree 文件系统访问约定
-
-插入位置：`## Communication` 与 `## Lead` 之间，作为新的顶层段。
-
-```markdown
-## Worktree Filesystem Access
-
-Worktrees share `.git` but have isolated working trees. **`.gitignored` artifacts do not propagate across worktrees**:
-- `node_modules/` / `dist/` / build caches
-- Manually cloned reference repos (e.g. `docs/research/reference-repos/<repo>/`)
-- Local secrets / configs (`.env`, `.claude/`, etc.)
-
-When an agent working inside a worktree needs these resources:
-
-| Operation | Path |
-|---|---|
-| **Read** main repo's `.gitignored` resources | `$ORCA_ROOT/<path>` (main repo absolute path, env already set) |
-| **Write** task code | current worktree (`pwd`) |
-| **Write** cross-task shared research / reference data | `$ORCA_ROOT/<path>`, must be explicitly stated in the task |
-
-Do not re-install / re-clone / re-build resources that already exist in the main repo — wastes time and disk, and risks divergence from main repo state.
-```
-
-**起源**：与 Tier 1 无关。来自 worker 在 worktree 内重新 clone 资源的实际事故，抽象为一条 skill 层面的通用约束。
-
-### 实施 PR 的范围（独立）
-
-- [ ] 将规则 1 应用到 `skills/orca/SKILL.md`
-- [x] 将规则 2 应用到 `skills/orca/SKILL.md`
-- [ ] Smoke test：派一个会触发多行汇报的 worker，验证 `/tmp/orca-msg-*` 流程
-- [ ] Smoke test：派一个进入 worktree 后需要读取主仓 `node_modules` 或参考 clone 的 worker，验证 `$ORCA_ROOT` 访问可用
 
 ## P1: Workflow Skills
 

--- a/docs/proposals/mixed.md
+++ b/docs/proposals/mixed.md
@@ -8,8 +8,8 @@
 
 | # | 标题 | 分类 | 状态 | 优先级 | 触发频率 |
 |---|---|---|---|---|---|
-| 1 | tmux-bridge message 引号被吃 | A 通信 | 方案 A/B 暂存为 fallback；新主线 Tier 1 (paste-buffer)，见 PLAN | **P0** | 高，反复触发 |
-| 2 | PreToolUse hook 给 tmux-bridge 放行 | B 权限 | Tier 1 后预期消失（命令体不再含 $(...)），待 Tier 1 验证后再评估 | P1 | 高 |
+| 1 | tmux-bridge message 引号被吃 | A 通信 | **已落地**（D10：方案 A 单引号包裹为默认；方案 B 落盘仅在内容含 `'` 或换行时触发） | ~~P0~~ | — |
+| 2 | PreToolUse hook 给 tmux-bridge 放行 | B 权限 | D10 后 `tmux-bridge message` 体不再含 `$(...)`（heredoc 改为独立命令、message 体只含路径或单行字面量），本提案现象大概率消失，待重新评估 | P1 | 待复测 |
 | 3 | PreToolUse hook 给只读命令 simple_expansion 放行 | B 权限 | 待决策 | P1 | 中 |
 | 4 | tmux copy mode 软折行 / mouse bypass | C 终端 | 调研完成 | P2 | 中 |
 | 5 | Zed 终端 link 点击需 shift+cmd | C 终端 | 待决策 | P3 | 低 |
@@ -31,16 +31,20 @@
 
 ## 1. tmux-bridge message 引号被吃
 
-**分类**：A 通信。**状态**：方案 A 已落地（skill 文档约束单引号，仅适用单行），方案 B（多行落盘传递）待推进。**优先级 P0**。
+**分类**：A 通信。**状态**：**已落地**（D10：方案 A + B 组合为主线规则，写入 `skills/orca/SKILL.md` Communication 段）。**优先级**：~~P0~~ 已解决。
 
-### 2026-04-20 重新评估（新主线：Tier 1 paste-buffer）
+### 2026-04-21 终局决策（D10）
 
-参考 `docs/research/stably-orca-compare.md` 对 stablyai/orca 的架构对比（第 4 条启发：减少把结构化控制塞入 shell 命令参数），本提案方向重定向：
+实测对比方案后定案：
 
-- **新主线**：tmux `load-buffer + paste-buffer` 通信改造（Tier 1），完全绕开 bash 解析阶段。详见 `PLAN.md` 中「通信层重构（Tier 1：paste-buffer）」章节
-- **方案 A（单引号约束）**：保留为 fallback，仅作为单行短消息的轻量路径
-- **方案 B（落盘 + 路径传递）**：保留为 debug / 跨 worker 复用场景的 fallback，不再作为多行消息的默认路径
-- 原 P0 优先级保留，但实施路径切换到 Tier 1
+- **方案 A（单引号包裹 inline message）** = 默认路径。`'...'` 内 `$`/backtick/`"`/`\` 都是字面量，覆盖绝大多数短消息
+- **方案 B（落盘 + 路径传递）** = 触发条件收窄到「内容含 `'` 或换行」。worker → lead 与 lead → worker 对称
+- **Tier 1（`tmux load-buffer + paste-buffer`）** 已弃用：实测内容传递无损，但 Codex 多行粘贴提交需 Enter×2（时序敏感）、且全文进 worker 对话历史（compact 后失忆）。详见 PLAN D10 决策行
+- 不修 smux 上游（`tmux-bridge message` 的 bash 解析问题保留），靠 SKILL 纪律绕开
+
+### 2026-04-20 重新评估（已废弃，保留作历史记录）
+
+> 当时方向：tmux `load-buffer + paste-buffer` (Tier 1) 改造为新主线，2026-04-21 实测后被 D10 推翻。
 
 ### 现象
 
@@ -143,13 +147,13 @@ tmux-bridge message "$ORCA_PEER" "Read $msg_path"
 
 **分类**：B 权限。**状态**：待决策（倾向落地）。**优先级 P1**。
 
-### Tier 1 影响（待 Tier 1 验证后再评估）
+### D10 后的影响（待复测）
 
-Tier 1 (paste-buffer) 完成后，`tmux-bridge` 命令体不再包含 `$(...)` 命令替换（内容通过 buffer 而非命令参数传递）。预期效果：
+D10 落地后，`tmux-bridge message` 的命令体不再含 `$(...)` —— heredoc 写文件是独立命令，message 体只放路径或单行字面量。预期效果：
 
 - Claude Code permission matcher 不再因 `$(...)` 触发降级 → 本提案的 ask-prompt 现象大概率自动消失
-- 若验证后确实消失，本提案可降级为 P3 或并入 #3（共同根因仍是 matcher 对 shell expansion 的保守降级）
-- 若 Tier 1 后仍有残留场景，再评估是否单独落地 PreToolUse hook
+- 若复测确认消失，本提案可降级为 P3 或并入 #3（共同根因仍是 matcher 对 shell expansion 的保守降级）
+- 若仍有残留场景（如 worker 临时偷懒写 `$(cat ...)`），再评估是否落地 PreToolUse hook
 
 ### 现象
 

--- a/skills/orca/SKILL.md
+++ b/skills/orca/SKILL.md
@@ -34,25 +34,39 @@ If `$ORCA_WORKFLOW` is set, invoke the workflow skill after this skill loads:
 One command, always chain with `&&`:
 
 ````bash
-tmux-bridge read $ORCA_PEER 5 && tmux-bridge message $ORCA_PEER "msg" && tmux-bridge read $ORCA_PEER 5 && tmux-bridge keys $ORCA_PEER Enter
+tmux-bridge read $ORCA_PEER 5 && tmux-bridge message $ORCA_PEER 'msg' && tmux-bridge read $ORCA_PEER 5 && tmux-bridge keys $ORCA_PEER Enter
 ````
 
-Read Guard: must `read` before every `type`/`keys`.
+- Read Guard: must `read` before every `type`/`keys`.
+- Multi-worker: use specific label from `$ORCA_WORKERS` instead of `$ORCA_PEER`.
 
-Multi-worker: use specific label from `$ORCA_WORKERS` instead of `$ORCA_PEER`.
+**Wrap message body in single quotes.** Inside `'...'`, `$`, backticks, `"`, `\`, and Chinese are literal — safe to send as-is.
+
+**Switch to file delivery only when content contains `'` or newlines.** Applies symmetrically to lead → worker dispatch and worker → lead reports.
+
+````bash
+msg_path="/tmp/orca-msg-<slug>-$(date +%s).md"
+cat > "$msg_path" <<'EOF'
+Body can include 'quotes', real newlines, $vars, `backticks`, code blocks.
+EOF
+tmux-bridge read $ORCA_PEER 5 && tmux-bridge message $ORCA_PEER "Read $msg_path" && tmux-bridge read $ORCA_PEER 5 && tmux-bridge keys $ORCA_PEER Enter
+````
+
+The `"Read $msg_path"` line uses double quotes intentionally — the body is a known-safe template (`Read ` + a controlled variable), so variable expansion is required and there is nothing else to escape. The single-quote default applies to free-form message content.
 
 ## Worktree Filesystem Access
 
-Worktrees share `.git` but have isolated working trees. `.gitignored` resources do not propagate across worktrees.
+Worktrees share `.git` but have isolated working trees. Tracked files are checked out into every worktree; `.gitignored` resources (`node_modules/`, build outputs, `.env`, manually cloned reference repos under `docs/research/reference-repos/`) do not propagate.
 
 | Operation | Path |
 |---|---|
-| Read main repo's tracked or read-only reference resources | `$ORCA_ROOT/<path>` |
-| Install / build / test / run worktree code | per-worktree install (package managers reuse their global cache) |
-| Write task code | current worktree (`pwd`) |
-| Write cross-task shared resources | `$ORCA_ROOT/<path>`, only when explicitly authorized by the task |
+| Read or edit any tracked file for the task (`README.md`, `src/foo.ts`, even `skills/orca/SKILL.md`) | current worktree (`pwd`) |
+| Read main repo's `.gitignored` reference material (e.g. cloned reference repos) that doesn't exist in your worktree | `$ORCA_ROOT/<path>` |
+| Install / build / test | run inside the worktree (`pnpm install` etc.); package managers reuse their own global cache — do not symlink `node_modules` from main repo |
+| Local untracked files (`.env`, build outputs) | stay in current worktree; never write to `$ORCA_ROOT` |
+| Write to main repo on purpose (shared docs that bypass the branch, e.g. cross-task research note) | `$ORCA_ROOT/<path>`, only when the task explicitly authorizes it |
 
-Do not share dependency directories across worktrees, and do not re-create read-only references that already exist in the main repo. See `docs/research/git-worktree-build-practices.md` for sources.
+See `docs/research/git-worktree-build-practices.md` for sources.
 
 ## Lead
 
@@ -61,7 +75,7 @@ Do not share dependency directories across worktrees, and do not re-create read-
    - Single worker: use `$ORCA_PEER`
    - Multi-worker: iterate `$ORCA_WORKERS` (comma-separated), dispatch to each
    - Worktree: run `orca-worktree create <slug>` first (`<slug>` = kebab-case feature name, e.g. `auth-refactor`; append `-<n>` only when multiple workers share that feature), then tell worker to `cd` into it
-   - **Long-context tasks**: write full plan to `/tmp/orca-handoff-<task-slug>-<timestamp>.md` and tell worker to read that path. Survives tmux-bridge truncation and context compaction.
+   - Multi-line dispatches use file delivery (see Communication). Path-only message keeps worker context lean and survives compaction.
 3. **Wait** — say "dispatched, waiting" and **end turn**. Do not poll.
    - Heartbeat: `[orca]` idle notifications surface on lead's next tool use (PreToolUse hook). For immediate awareness, `tmux-bridge read <worker>` to check pane.
    - Idle = no tool calls in 30s. Could mean done, stuck, or waiting. Check worker pane to determine next action.
@@ -72,7 +86,7 @@ Do not share dependency directories across worktrees, and do not re-create read-
 
 1. **Wait** — reply "Worker ready." in own pane (do not message lead) and end turn
 2. **Implement** -> **Self-review** (/review, fix, repeat) -> **Test** (build + tests)
-3. **Report** — 1-2 sentence summary to lead, no code/diffs
+3. **Report** — 1-2 sentence summary to lead, no code/diffs (see Communication for inline vs file)
 
 Workers can also initiate: ask lead for help or confirm approach.
 


### PR DESCRIPTION
## 摘要
- **D10 决策**：`tmux-bridge message` 默认 inline 单引号包裹；只有内容含 `'` 或换行时才走文件投递（`/tmp/orca-msg-*.md`）。lead → worker 派单与 worker → lead 汇报对称
- **Worktree FS access** 文案重写：拆分 tracked 与参考资源、显式列出 install 位置 / 本地未跟踪文件（`.env`）/ 授权后的跨任务写入，解决 worker 第一视角审视抓出的 6 处歧义
- **PLAN 清理**：D10 写入 Decisions 表；删除被推翻的 Tier 1 paste-buffer 计划与「待落地 Skill 规则」整段
- **mixed.md 同步**：提案 #1 标记已落地（D10 解决）、#2 改为「D10 后重新评估」

## 为什么选 D10 而不是 paste-buffer (Tier 1)
两个方案本分支内都实测过：
- paste-buffer（`tmux load-buffer + paste-buffer`）：内容传递无损，但 Codex 多行粘贴提交需 Enter×2（时序敏感），且全文进 worker 对话历史（compact 后失忆）
- 文件投递：worker 上下文精简（消息体只含路径）、可审计、单一心智模型

单引号 inline 让文件投递的触发条件收窄到只剩「内容含 `'` 或换行」，大多数短消息仍然 inline。`tmux-bridge` 源码在 smux 上游，不动代码层守卫，靠 SKILL 纪律执行。

## 测试计划
- [x] inline 单引号路径：本分支编写过程中持续实测
- [x] 文件投递路径：实测两次（worker 第一次审视 + 交叉审视）
- [x] paste-buffer 对照测试（D10 决策依据）
- [x] worker 第一视角审 Worktree 文案 → 解决 3 处早期歧义
- [x] worker 交叉审完整 diff → 抓出 2 处问题，已修
- [x] lead `/review` 跑 diff → 抓出 D10 行措辞反向问题，已修
- [x] Worktree `$ORCA_ROOT` 访问烟测 — PASS（commit 0e0996e）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
