### PR TITLE
feat: 同目录多实例支持

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,4 @@ docs/               → architecture decisions
 - English comments and output
 - Shell: `set -euo pipefail`, quote variables
 - Commits: `<type>: <description>`
+- Git in worktrees: prefer `git -C <repo-path>` over `cd <worktree> && git ...` for HEAD-affecting commands (`checkout`, `reset`, `merge`). A `cd` chain makes it trivial to mutate the wrong worktree's HEAD.

--- a/_lib.sh
+++ b/_lib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Shared helpers for orca subcommand scripts (ps, rm, prune).
+# Shared helpers for orca subcommand scripts.
 # Sourced; not executable on its own.
 
 # Directory tmux uses for per-user sockets. macOS symlinks /tmp -> /private/tmp,
@@ -16,6 +16,31 @@ is_dead_socket() {
   local sock="$1"
   [ -S "$sock" ] || return 1
   ! tmux -S "$sock" list-sessions &>/dev/null
+}
+
+# Sanitize basename: tmux uses `.` and `:` as target separators
+# (session:window.pane), so dirs containing them break tmux targeting.
+sanitize_dirname() {
+  basename "$1" | tr '.:' '--'
+}
+
+base_session_name() {
+  printf 'orca-%s' "$(sanitize_dirname "$1")"
+}
+
+format_session_timestamp() {
+  local epoch="$1"
+  if date -r "$epoch" '+%Y%m%d%H%M%S' >/dev/null 2>&1; then
+    date -r "$epoch" '+%Y%m%d%H%M%S'
+  else
+    date -d "@$epoch" '+%Y%m%d%H%M%S'
+  fi
+}
+
+socket_name_exists() {
+  local socket_name="$1"
+  local dir; dir=$(tmux_socket_dir)
+  [ -n "$dir" ] && [ -S "$dir/$socket_name" ]
 }
 
 # List all live dedicated orca sockets (one socket name per line).
@@ -45,6 +70,121 @@ list_dedicated_dead() {
 # List orca-named sessions on the user's main tmux server (one name per line).
 list_legacy_sessions() {
   tmux ls -F '#{session_name}' 2>/dev/null | grep -E '^orca-' || true
+}
+
+# Emit all live orca instances as:
+# type|socket_name|session_name|attached(0|1)|created_epoch|panes|cwd
+#
+# Pane count comes from #{window_panes} of window 0. orca always creates one
+# window named 'main', so this is the total pane count under that contract; a
+# user who manually adds windows would see an undercount.
+list_all_instances() {
+  local sock_name info name attached created panes cwd legacy_table
+
+  while IFS= read -r sock_name; do
+    [ -n "$sock_name" ] || continue
+    info=$(tmux -L "$sock_name" list-sessions \
+      -F '#{session_name}|#{session_attached}|#{session_created}' \
+      2>/dev/null) || continue
+    [ -n "$info" ] || continue
+    IFS='|' read -r name attached created <<<"$info"
+    [ -n "$name" ] || continue
+    info=$(tmux -L "$sock_name" display-message -p -t "${name}:0.0" \
+      -F '#{window_panes}|#{pane_current_path}' 2>/dev/null) || info='?|?'
+    IFS='|' read -r panes cwd <<<"$info"
+    printf 'isolated|%s|%s|%s|%s|%s|%s\n' "$sock_name" "$name" "$attached" "$created" "$panes" "$cwd"
+  done < <(list_dedicated_live)
+
+  legacy_table=$(tmux ls -F '#{session_name}|#{session_attached}|#{session_created}' 2>/dev/null || true)
+  [ -n "$legacy_table" ] || return 0
+  while IFS='|' read -r name attached created; do
+    case "$name" in orca-*) ;; *) continue ;; esac
+    info=$(tmux display-message -p -t "${name}:0.0" \
+      -F '#{window_panes}|#{pane_current_path}' 2>/dev/null) || info='?|?'
+    IFS='|' read -r panes cwd <<<"$info"
+    printf 'main-tmux||%s|%s|%s|%s|%s\n' "$name" "$attached" "$created" "$panes" "$cwd"
+  done <<<"$legacy_table"
+}
+
+# Emit dedicated instances in the given cwd as:
+# socket_name|session_name|attached(0|1)|created_epoch|panes
+list_instances_in_cwd() {
+  local target_cwd="$1"
+  local type socket_name session_name attached created panes cwd
+
+  while IFS='|' read -r type socket_name session_name attached created panes cwd; do
+    [ "$type" = "isolated" ] || continue
+    [ "$cwd" = "$target_cwd" ] || continue
+    printf '%s|%s|%s|%s|%s\n' "$socket_name" "$session_name" "$attached" "$created" "$panes"
+  done < <(list_all_instances)
+}
+
+# Emit all instances in the given cwd as:
+# type|socket_name|session_name|attached(0|1)|created_epoch|panes|cwd
+list_all_instances_in_cwd() {
+  local target_cwd="$1"
+  local type socket_name session_name attached created panes cwd
+
+  while IFS='|' read -r type socket_name session_name attached created panes cwd; do
+    [ "$cwd" = "$target_cwd" ] || continue
+    printf '%s|%s|%s|%s|%s|%s|%s\n' \
+      "$type" "$socket_name" "$session_name" "$attached" "$created" "$panes" "$cwd"
+  done < <(list_all_instances)
+}
+
+instance_name_exists() {
+  local target_name="$1"
+  local _t _s session_name _a _c _p _w
+
+  while IFS='|' read -r _t _s session_name _a _c _p _w; do
+    [ "$session_name" = "$target_name" ] && return 0
+  done < <(list_all_instances)
+  return 1
+}
+
+next_session_name() {
+  local cwd="$1"
+  local base_name epoch stamp candidate
+
+  base_name=$(base_session_name "$cwd")
+  epoch=$(date +%s)
+
+  while :; do
+    stamp=$(format_session_timestamp "$epoch")
+    candidate="${base_name}-${stamp}"
+    if ! socket_name_exists "$candidate" && ! instance_name_exists "$candidate"; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+    epoch=$((epoch + 1))
+  done
+}
+
+# Resolve a target (short_id or session name) to one row from
+# list_all_instances. Caller decides what to do on ambiguity.
+# Exit codes:
+#   0 — unique match (one row on stdout)
+#   1 — no match (error on stderr)
+#   2 — multiple matches (all matching rows on stdout)
+resolve_target_by_id_or_name() {
+  local target="$1"
+  local row id type socket_name name attached created panes cwd
+  local matches=()
+
+  while IFS='|' read -r type socket_name name attached created panes cwd; do
+    if is_short_id "$target"; then
+      id=$(short_id "$type:$name:$cwd")
+      [ "$id" = "$target" ] && matches+=("$type|$socket_name|$name|$attached|$created|$panes|$cwd")
+    else
+      [ "$name" = "$target" ] && matches+=("$type|$socket_name|$name|$attached|$created|$panes|$cwd")
+    fi
+  done < <(list_all_instances)
+
+  case "${#matches[@]}" in
+    0) echo "No orca instance matches '$target'" >&2; return 1 ;;
+    1) printf '%s\n' "${matches[0]}"; return 0 ;;
+    *) printf '%s\n' "${matches[@]}"; return 2 ;;
+  esac
 }
 
 # Format Unix-epoch seconds-since timestamp into compact uptime (e.g. 3h12m, 28m).
@@ -92,6 +232,308 @@ color_status() {
   esac
 }
 
+format_picker_row() {
+  local session_name="$1"
+  local status="$2"
+  local panes="$3"
+  local uptime="$4"
+
+  printf '%-32s  %-8s  %5s panes  %s' "$session_name" "$status" "$panes" "$uptime"
+}
+
+# Numbered single-select picker.
+# Usage: pick_one PROMPT NEW_LABEL OPTION1 [OPTION2 ...]
+# - NEW_LABEL: empty disables the "n) ..." choice; otherwise shown as `n)`
+# - Empty input picks option 1 (default).
+# Output: 1-based index, or "NEW" when user picks the new option.
+# Returns 1 on quit/cancel.
+pick_one() {
+  local prompt="$1"
+  local new_label="$2"
+  shift 2
+  local options=("$@")
+  local count="${#options[@]}"
+  local i choice range_suffix
+
+  [ "$count" -gt 0 ] || return 1
+
+  for ((i = 0; i < count; i++)); do
+    if [ "$i" -eq 0 ]; then
+      printf '  %d) %s  <- default\n' "$((i + 1))" "${options[$i]}"
+    else
+      printf '  %d) %s\n' "$((i + 1))" "${options[$i]}"
+    fi
+  done
+
+  if [ -n "$new_label" ]; then
+    printf '  n) %s\n' "$new_label"
+    range_suffix="1-${count}/n/q"
+  else
+    range_suffix="1-${count}/q"
+  fi
+
+  while :; do
+    read -rp "${prompt} [${range_suffix}] (default: 1): " choice
+    case "$choice" in
+      "")
+        printf '1\n'
+        return 0
+        ;;
+      [qQ])
+        return 1
+        ;;
+      [nN])
+        if [ -n "$new_label" ]; then
+          printf 'NEW\n'
+          return 0
+        fi
+        ;;
+    esac
+
+    if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "$count" ]; then
+      printf '%s\n' "$choice"
+      return 0
+    fi
+
+    echo "Invalid choice" >&2
+  done
+}
+
+# TUI single-select renderer — file-scope, reads state via dynamic scope
+# from pick_one_tui's locals (prompt, hint, count, current, options).
+# Reuses _pick_many_clear (lines is set by the caller to match this layout).
+_pick_one_tui_render() {
+  local row
+  tput rc
+  printf '%s' "$prompt"
+  tput el
+  printf '\n'
+  if [ -n "$hint" ]; then
+    printf '%s' "$hint"
+    tput el
+    printf '\n'
+  fi
+  for ((row = 0; row < count; row++)); do
+    if [ "$row" -eq "$current" ]; then
+      printf '\033[38;5;117m> %s\033[0m' "${options[$row]}"
+    else
+      printf '  %s' "${options[$row]}"
+    fi
+    tput el
+    if [ "$row" -lt $((count - 1)) ]; then
+      printf '\n'
+    fi
+  done
+}
+
+# TUI single-select picker. Last appended option (when new_label non-empty)
+# is the "new" entry; picking it returns the literal string "NEW" instead of
+# its index. Returns 1 on quit/cancel.
+# Usage: pick_one_tui PROMPT HINT NEW_LABEL OPTION1 [OPTION2 ...]
+pick_one_tui() {
+  local prompt="$1"
+  local hint="$2"
+  local new_label="$3"
+  shift 3
+  local options=("$@")
+
+  if [ -n "$new_label" ]; then
+    options+=("$new_label")
+  fi
+
+  local count="${#options[@]}"
+  [ "$count" -gt 0 ] || return 1
+  if ! { : >/dev/tty; } 2>/dev/null; then
+    echo "Error: picker requires a TTY" >&2
+    return 1
+  fi
+
+  (
+    # stdout is captured by `$(...)`; route UI to /dev/tty and keep the
+    # original stdout on FD 5 for emitting the result.
+    exec 5>&1 >/dev/tty </dev/tty
+
+    local current=0
+    local lines=$((count + 1))
+    [ -n "$hint" ] && lines=$((lines + 1))
+    local key extra
+
+    trap '_pick_many_clear 2>/dev/null || true; tput cnorm 2>/dev/null || true' EXIT
+
+    tput sc
+    tput civis
+    _pick_one_tui_render
+
+    while :; do
+      IFS= read -rsn1 key || continue
+      if [ "$key" = $'\e' ]; then
+        extra=''
+        read -rsn2 -t 0.001 extra || true
+        key="${key}${extra}"
+      fi
+
+      case "$key" in
+        $'\e[A'|k)
+          if [ "$current" -gt 0 ]; then
+            current=$((current - 1))
+          else
+            current=$((count - 1))
+          fi
+          ;;
+        $'\e[B'|j)
+          if [ "$current" -lt $((count - 1)) ]; then
+            current=$((current + 1))
+          else
+            current=0
+          fi
+          ;;
+        q|Q|$'\e')
+          exit 1
+          ;;
+        $'\n'|$'\r'|'')
+          if [ -n "$new_label" ] && [ "$current" -eq $((count - 1)) ]; then
+            printf 'NEW' >&5
+          else
+            printf '%d' $((current + 1)) >&5
+          fi
+          exit 0
+          ;;
+      esac
+
+      _pick_one_tui_render
+    done
+  )
+}
+
+# TUI checkbox helpers — file-scope so they aren't redefined per call. They
+# read picker state via dynamic scope from pick_many_tui's locals
+# (prompt, hint, count, current, lines, selected, options).
+_pick_many_render() {
+  local row marker
+  tput rc
+  printf '%s' "$prompt"
+  tput el
+  printf '\n'
+  if [ -n "$hint" ]; then
+    printf '%s' "$hint"
+    tput el
+    printf '\n'
+  fi
+  for ((row = 0; row < count; row++)); do
+    marker='[ ]'
+    [ "${selected[$row]}" -eq 1 ] && marker='[x]'
+    if [ "$row" -eq "$current" ]; then
+      printf '\033[38;5;117m%s %s\033[0m' "$marker" "${options[$row]}"
+    else
+      printf '%s %s' "$marker" "${options[$row]}"
+    fi
+    tput el
+    if [ "$row" -lt $((count - 1)) ]; then
+      printf '\n'
+    fi
+  done
+}
+
+_pick_many_clear() {
+  local row
+  tput rc
+  for ((row = 0; row < lines; row++)); do
+    tput el
+    if [ "$row" -lt $((lines - 1)) ]; then
+      tput cud1
+    fi
+  done
+  tput rc
+  tput cnorm
+}
+
+# TUI multi-select picker. Returns picked indices (1-based) on stdout, one
+# per line. Returns 1 on quit/cancel.
+# Wrapped in a subshell so the EXIT trap reliably restores cursor + screen
+# state even if the body errors out under `set -e`.
+pick_many_tui() {
+  local prompt="$1"
+  local hint="$2"
+  shift 2
+  local options=("$@")
+  local count="${#options[@]}"
+
+  [ "$count" -gt 0 ] || return 0
+  if ! { : >/dev/tty; } 2>/dev/null; then
+    echo "Error: stop picker requires a TTY" >&2
+    return 1
+  fi
+
+  (
+    # stdout is captured by `$(...)`; route UI to /dev/tty and keep the
+    # original stdout on FD 5 for emitting the result.
+    exec 5>&1 >/dev/tty </dev/tty
+
+    local current=0
+    local lines=$((count + 1))
+    [ -n "$hint" ] && lines=$((lines + 1))
+    local key extra output i
+    local -a selected
+    for ((i = 0; i < count; i++)); do
+      selected[$i]=0
+    done
+
+    trap '_pick_many_clear 2>/dev/null || true; tput cnorm 2>/dev/null || true' EXIT
+
+    tput sc
+    tput civis
+    _pick_many_render
+
+    while :; do
+      IFS= read -rsn1 key || continue
+      if [ "$key" = $'\e' ]; then
+        extra=''
+        read -rsn2 -t 0.001 extra || true
+        key="${key}${extra}"
+      fi
+
+      case "$key" in
+        $'\e[A'|k)
+          if [ "$current" -gt 0 ]; then
+            current=$((current - 1))
+          else
+            current=$((count - 1))
+          fi
+          ;;
+        $'\e[B'|j)
+          if [ "$current" -lt $((count - 1)) ]; then
+            current=$((current + 1))
+          else
+            current=0
+          fi
+          ;;
+        ' ')
+          if [ "${selected[$current]}" -eq 1 ]; then
+            selected[$current]=0
+          else
+            selected[$current]=1
+          fi
+          ;;
+        q|Q|$'\e')
+          exit 1
+          ;;
+        $'\n'|$'\r'|'')
+          output=''
+          for ((i = 0; i < count; i++)); do
+            if [ "${selected[$i]}" -eq 1 ]; then
+              output="${output}$((i + 1))"$'\n'
+            fi
+          done
+          printf '%s' "$output" >&5
+          exit 0
+          ;;
+      esac
+
+      _pick_many_render
+    done
+  )
+}
+
 # Short, stable hash id for an instance. Input should be a unique tuple of the
 # instance's stable attributes (e.g. "isolated:orca-foo:/path/to/cwd"). 6 hex
 # chars = 16M possibilities, ample headroom for the handful of instances a
@@ -112,4 +554,48 @@ short_id() {
 # True if input looks like a short_id (6 lowercase hex chars).
 is_short_id() {
   [[ "$1" =~ ^[0-9a-f]{6}$ ]]
+}
+
+cleanup_monitor_pids() {
+  local session_name="$1"
+  local pid_file monitor_pid
+
+  for pid_file in /tmp/orca-monitor-"${session_name}"-*.pid; do
+    [ -f "$pid_file" ] || continue
+    kill "$(cat "$pid_file")" 2>/dev/null || true
+    rm -f "$pid_file"
+  done
+
+  monitor_pid="/tmp/orca-monitor-${session_name}.pid"
+  if [ -f "$monitor_pid" ]; then
+    kill "$(cat "$monitor_pid")" 2>/dev/null || true
+    rm -f "$monitor_pid"
+  fi
+}
+
+cleanup_heartbeat_dir() {
+  local repo_root="$1"
+  local session_name="$2"
+  local dir="${repo_root}/.orca/heartbeat/${session_name}"
+
+  rm -rf "$dir" 2>/dev/null || true
+}
+
+stop_instance() {
+  local type="$1"
+  local socket_name="$2"
+  local session_name="$3"
+  local repo_root="$4"
+
+  cleanup_monitor_pids "$session_name"
+  cleanup_heartbeat_dir "$repo_root" "$session_name"
+
+  case "$type" in
+    isolated)
+      tmux -L "$socket_name" kill-server 2>/dev/null || true
+      ;;
+    main-tmux)
+      tmux kill-session -t "$session_name" 2>/dev/null || true
+      ;;
+  esac
 }

--- a/hooks/check-heartbeat.sh
+++ b/hooks/check-heartbeat.sh
@@ -3,7 +3,7 @@
 [[ -z "${ORCA:-}" ]] && exit 0
 [[ "${ORCA_ROLE:-}" != "lead" ]] && exit 0
 
-HEARTBEAT_DIR="${ORCA_ROOT:-.}/.orca/heartbeat"
+HEARTBEAT_DIR="${ORCA_ROOT:-.}/.orca/heartbeat/${ORCA_SESSION:-shared}"
 [[ ! -d "$HEARTBEAT_DIR" ]] && exit 0
 
 COOLDOWN=30

--- a/hooks/post-tool-use.sh
+++ b/hooks/post-tool-use.sh
@@ -3,6 +3,6 @@
 [[ -z "${ORCA:-}" ]] && exit 0
 [[ "${ORCA_ROLE:-}" != "worker" ]] && exit 0
 
-HEARTBEAT_DIR="${ORCA_ROOT:-.}/.orca/heartbeat"
+HEARTBEAT_DIR="${ORCA_ROOT:-.}/.orca/heartbeat/${ORCA_SESSION:-shared}"
 mkdir -p "$HEARTBEAT_DIR"
 date +%s > "$HEARTBEAT_DIR/${ORCA_WORKER_ID:-0}"

--- a/ps.sh
+++ b/ps.sh
@@ -5,72 +5,52 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=_lib.sh
 source "$SCRIPT_DIR/_lib.sh"
 
-# Collect rows: each row is "ID\tNAME\tTYPE\tSTATUS\tCWD\tPANES\tUPTIME"
-# STATUS is plain text here; coloring happens at print time so column widths
-# can be computed from visible length. ID is short_id derived from the stable
-# tuple "type:name:cwd".
 rows=()
-
-# Isolated instances: each on a per-instance dedicated tmux server (D8).
-while IFS= read -r sock_name; do
-  [ -z "$sock_name" ] && continue
-  info=$(tmux -L "$sock_name" ls -F '#{session_name}|#{session_attached}|#{session_created}|#{session_windows}' 2>/dev/null | head -1)
-  [ -z "$info" ] && continue
-  IFS='|' read -r name attached created windows <<<"$info"
+while IFS='|' read -r type socket_name name attached created panes cwd; do
+  [ -n "$type" ] || continue
   status=$([ "$attached" = "1" ] && echo "attached" || echo "detached")
-  panes=$(tmux -L "$sock_name" list-panes -s -t "$name" 2>/dev/null | wc -l | tr -d ' ')
-  cwd=$(tmux -L "$sock_name" display-message -p -t "$name:0.0" '#{pane_current_path}' 2>/dev/null || echo '?')
-  id=$(short_id "isolated:$name:$cwd")
-  rows+=("$id	$name	isolated	$status	$(shorten_path "$cwd")	$panes	$(format_uptime "$created")")
-done < <(list_dedicated_live)
+  id=$(short_id "$type:$name:$cwd")
+  rows+=("$cwd|$created|$id|$name|$type|$status|$panes|$(format_uptime "$created")")
+done < <(list_all_instances)
 
-# Sessions on user's main tmux server (pre-D8 era; orphans after D8 upgrade).
-while IFS= read -r sname; do
-  [ -z "$sname" ] && continue
-  info=$(tmux ls -F '#{session_name}|#{session_attached}|#{session_created}|#{session_windows}' 2>/dev/null \
-    | grep -E "^${sname}\|" | head -1)
-  [ -z "$info" ] && continue
-  IFS='|' read -r name attached created windows <<<"$info"
-  status=$([ "$attached" = "1" ] && echo "attached" || echo "detached")
-  panes=$(tmux list-panes -s -t "$name" 2>/dev/null | wc -l | tr -d ' ')
-  cwd=$(tmux display-message -p -t "$name:0.0" '#{pane_current_path}' 2>/dev/null || echo '?')
-  id=$(short_id "main-tmux:$name:$cwd")
-  rows+=("$id	$name	main-tmux	$status	$(shorten_path "$cwd")	$panes	$(format_uptime "$created")")
-done < <(list_legacy_sessions)
-
-# Render
-if [ ${#rows[@]} -eq 0 ]; then
+if [ "${#rows[@]}" -eq 0 ]; then
   echo "No orca instances running"
 else
-  # Compute per-column max widths (visible length, no color codes here)
-  w_id=2 w_name=4 w_type=4 w_status=6 w_cwd=3 w_panes=5 w_uptime=6
+  w_id=2
+  w_name=4
+  w_type=4
+  w_status=6
+  w_panes=5
+  w_uptime=6
+
   for row in "${rows[@]}"; do
-    IFS=$'\t' read -r i n t s c p u <<<"$row"
-    (( ${#i} > w_id )) && w_id=${#i}
-    (( ${#n} > w_name )) && w_name=${#n}
-    (( ${#t} > w_type )) && w_type=${#t}
-    (( ${#s} > w_status )) && w_status=${#s}
-    (( ${#c} > w_cwd )) && w_cwd=${#c}
-    (( ${#p} > w_panes )) && w_panes=${#p}
-    (( ${#u} > w_uptime )) && w_uptime=${#u}
+    IFS='|' read -r cwd created id name type status panes uptime <<<"$row"
+    (( ${#id} > w_id )) && w_id=${#id}
+    (( ${#name} > w_name )) && w_name=${#name}
+    (( ${#type} > w_type )) && w_type=${#type}
+    (( ${#status} > w_status )) && w_status=${#status}
+    (( ${#panes} > w_panes )) && w_panes=${#panes}
+    (( ${#uptime} > w_uptime )) && w_uptime=${#uptime}
   done
 
-  # Header
-  printf "%-${w_id}s  %-${w_name}s  %-${w_type}s  %-${w_status}s  %-${w_cwd}s  %${w_panes}s  %s\n" \
-    "ID" "NAME" "TYPE" "STATUS" "CWD" "PANES" "UPTIME"
+  current_cwd=''
+  while IFS='|' read -r cwd created id name type status panes uptime; do
+    if [ "$cwd" != "$current_cwd" ]; then
+      [ -z "$current_cwd" ] || echo
+      echo "cwd: $(shorten_path "$cwd")"
+      printf "  %-${w_id}s  %-${w_name}s  %-${w_type}s  %-${w_status}s  %${w_panes}s  %s\n" \
+        "ID" "NAME" "TYPE" "STATUS" "PANES" "UPTIME"
+      current_cwd="$cwd"
+    fi
 
-  # Rows — STATUS is colored; pad as if uncolored so alignment holds.
-  for row in "${rows[@]}"; do
-    IFS=$'\t' read -r i n t s c p u <<<"$row"
-    printf "%-${w_id}s  %-${w_name}s  %-${w_type}s  " "$i" "$n" "$t"
-    printf "%s" "$(color_status "$s")"
-    pad=$(( w_status - ${#s} ))
+    printf "  %-${w_id}s  %-${w_name}s  %-${w_type}s  " "$id" "$name" "$type"
+    printf "%s" "$(color_status "$status")"
+    pad=$((w_status - ${#status}))
     (( pad > 0 )) && printf "%${pad}s" ""
-    printf "  %-${w_cwd}s  %${w_panes}s  %s\n" "$c" "$p" "$u"
-  done
+    printf "  %${w_panes}s  %s\n" "$panes" "$uptime"
+  done < <(printf '%s\n' "${rows[@]}" | sort -t '|' -k1,1 -k2,2n)
 fi
 
-# Dead socket hint
 dead_count=$(list_dedicated_dead | wc -l | tr -d ' ')
 if [ "$dead_count" -gt 0 ]; then
   echo

--- a/rm.sh
+++ b/rm.sh
@@ -13,44 +13,11 @@ fi
 
 target="$1"
 
-# Enumerate every live instance once, computing id alongside. Each entry:
-# "id|type|name|cwd|panes"
-all=()
-
-while IFS= read -r sock_name; do
-  [ -z "$sock_name" ] && continue
-  cwd=$(tmux -L "$sock_name" display-message -p -t "$sock_name:0.0" '#{pane_current_path}' 2>/dev/null || echo '?')
-  panes=$(tmux -L "$sock_name" list-panes -s -t "$sock_name" 2>/dev/null | wc -l | tr -d ' ')
-  id=$(short_id "isolated:$sock_name:$cwd")
-  all+=("$id|isolated|$sock_name|$cwd|$panes")
-done < <(list_dedicated_live)
-
-while IFS= read -r sname; do
-  [ -z "$sname" ] && continue
-  cwd=$(tmux display-message -p -t "$sname:0.0" '#{pane_current_path}' 2>/dev/null || echo '?')
-  panes=$(tmux list-panes -s -t "$sname" 2>/dev/null | wc -l | tr -d ' ')
-  id=$(short_id "main-tmux:$sname:$cwd")
-  all+=("$id|main-tmux|$sname|$cwd|$panes")
-done < <(list_legacy_sessions)
-
-# Match strategy:
-#   1. If target looks like a short_id, match exclusively against ids (unique).
-#   2. Otherwise, match against names. Multiple matches → picker.
-matches=()
-if is_short_id "$target"; then
-  for entry in "${all[@]}"; do
-    IFS='|' read -r eid _ _ _ _ <<<"$entry"
-    [ "$eid" = "$target" ] && matches+=("$entry")
-  done
-else
-  for entry in "${all[@]}"; do
-    IFS='|' read -r _ _ ename _ _ <<<"$entry"
-    [ "$ename" = "$target" ] && matches+=("$entry")
-  done
-fi
+rc=0
+result=$(resolve_target_by_id_or_name "$target" 2>/dev/null) || rc=$?
 
 # Dead-socket fast path: no live match, but a dead inode with that name exists.
-if [ ${#matches[@]} -eq 0 ]; then
+if [ "$rc" -eq 1 ]; then
   if ! is_short_id "$target"; then
     dir=$(tmux_socket_dir)
     if [ -n "$dir" ] && [ -S "$dir/$target" ] && is_dead_socket "$dir/$target"; then
@@ -71,26 +38,32 @@ if [ ${#matches[@]} -eq 0 ]; then
 fi
 
 # Pick target — direct if unique, picker if name-based ambiguity.
-if [ ${#matches[@]} -eq 1 ]; then
-  chosen="${matches[0]}"
+if [ "$rc" -eq 0 ]; then
+  chosen="$result"
 else
+  matches=()
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    matches+=("$row")
+  done <<<"$result"
+
   echo "Multiple instances named '$target' (use the id to skip this picker):"
-  i=1
-  for c in "${matches[@]}"; do
-    IFS='|' read -r cid ctype cname ccwd cpanes <<<"$c"
-    printf "  %d) %s  %s  %s  %s panes  cwd: %s\n" "$i" "$cid" "$ctype" "$cname" "$cpanes" "$(shorten_path "$ccwd")"
-    i=$((i + 1))
+  picker_rows=()
+  for row in "${matches[@]}"; do
+    IFS='|' read -r mtype _msock mname mattached mcreated mpanes mcwd <<<"$row"
+    status=$([ "$mattached" = "1" ] && echo "attached" || echo "detached")
+    picker_rows+=("$(format_picker_row "$mname" "$status" "$mpanes" "$(format_uptime "$mcreated")")  $mtype  cwd: $(shorten_path "$mcwd")")
   done
-  echo
-  read -rp "Pick one [1-${#matches[@]}]: " pick
-  if ! [[ "$pick" =~ ^[0-9]+$ ]] || [ "$pick" -lt 1 ] || [ "$pick" -gt ${#matches[@]} ]; then
-    echo "Invalid choice" >&2
-    exit 1
+
+  if ! pick="$(pick_one "Pick one" "" "${picker_rows[@]}")"; then
+    echo "Cancelled"
+    exit 0
   fi
   chosen="${matches[$((pick - 1))]}"
 fi
 
-IFS='|' read -r tid ttype tname tcwd tpanes <<<"$chosen"
+IFS='|' read -r ttype tsocket tname _ta _tc tpanes tcwd <<<"$chosen"
+tid=$(short_id "$ttype:$tname:$tcwd")
 
 echo
 echo "About to remove:"
@@ -101,19 +74,8 @@ if [[ "$confirm" != [yY] ]]; then
   exit 0
 fi
 
+stop_instance "$ttype" "$tsocket" "$tname" "$tcwd"
 case "$ttype" in
-  isolated)
-    # Kill server (server only owns this one session, kill = clean env per D8)
-    tmux -L "$tname" kill-server 2>/dev/null || true
-    monitor_pid="/tmp/orca-monitor-${tname}.pid"
-    if [ -f "$monitor_pid" ]; then
-      kill "$(cat "$monitor_pid")" 2>/dev/null || true
-      rm -f "$monitor_pid"
-    fi
-    echo "Removed isolated instance: $tname"
-    ;;
-  main-tmux)
-    tmux kill-session -t "$tname" 2>/dev/null || true
-    echo "Removed main-tmux session: $tname"
-    ;;
+  isolated)  echo "Removed isolated instance: $tname" ;;
+  main-tmux) echo "Removed main-tmux session: $tname" ;;
 esac

--- a/start.sh
+++ b/start.sh
@@ -110,7 +110,14 @@ if ! command -v "$WORKER_BIN" &>/dev/null; then
 fi
 
 # --- Working directory ---
+# Canonicalize: tmux's #{pane_current_path} reports the resolved physical
+# path, so the cwd-equality check in list_instances_in_cwd needs the same
+# form. macOS /tmp -> /private/tmp is the common trigger.
 WORKDIR="${ORCA_WORKDIR:-$(pwd)}"
+WORKDIR=$(cd "$WORKDIR" 2>/dev/null && pwd -P) || {
+  echo "Error: cannot resolve working directory" >&2
+  exit 1
+}
 
 # --- Existing instances in this cwd ---
 existing=()

--- a/start.sh
+++ b/start.sh
@@ -28,14 +28,8 @@ case "${1:-}" in
     ;;
 esac
 
-# Sanitize basename: tmux uses `.` and `:` as target separators
-# (session:window.pane), so dirs containing them break tmux targeting.
-SESSION="orca-$(basename "$(pwd)" | tr '.:' '--')"
-# Per-instance dedicated tmux server: isolates orca from the user's main
-# tmux server so stop=kill-server gives a clean env on next start, and orca
-# never pollutes / inherits stale env from the user's long-lived server.
-SOCKET="$SESSION"
-TMUX_CMD="tmux -L $SOCKET"
+# shellcheck source=_lib.sh
+source "$SCRIPT_DIR/_lib.sh"
 
 # --- Defaults ---
 CODEX_DEFAULT_CMD="codex --sandbox danger-full-access -a on-request -c features.codex_hooks=true"
@@ -43,6 +37,7 @@ WORKERS=1
 LEAD_MODEL="claude"
 WORKER_MODEL="codex"
 WORKFLOW=""
+START_ARGS_PASSED=false
 
 # --- Usage ---
 usage() {
@@ -67,10 +62,10 @@ EOF
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    -n|--workers)  WORKERS="${2:?--workers requires a value}"; shift 2 ;;
-    --lead)        LEAD_MODEL="${2:?--lead requires a value}"; shift 2 ;;
-    --worker)      WORKER_MODEL="${2:?--worker requires a value}"; shift 2 ;;
-    -w|--workflow) WORKFLOW="${2:?--workflow requires a value}"; shift 2 ;;
+    -n|--workers)  WORKERS="${2:?--workers requires a value}"; START_ARGS_PASSED=true; shift 2 ;;
+    --lead)        LEAD_MODEL="${2:?--lead requires a value}"; START_ARGS_PASSED=true; shift 2 ;;
+    --worker)      WORKER_MODEL="${2:?--worker requires a value}"; START_ARGS_PASSED=true; shift 2 ;;
+    -w|--workflow) WORKFLOW="${2:?--workflow requires a value}"; START_ARGS_PASSED=true; shift 2 ;;
     -h|--help)     usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -114,14 +109,49 @@ if ! command -v "$WORKER_BIN" &>/dev/null; then
   exit 1
 fi
 
-# --- Reattach if exists ---
-if $TMUX_CMD has-session -t "$SESSION" 2>/dev/null; then
-  $TMUX_CMD attach -t "$SESSION"
-  exit 0
-fi
-
 # --- Working directory ---
 WORKDIR="${ORCA_WORKDIR:-$(pwd)}"
+
+# --- Existing instances in this cwd ---
+existing=()
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  existing+=("$row")
+done < <(list_instances_in_cwd "$WORKDIR" | sort -t '|' -k4,4nr)
+
+if [ "${#existing[@]}" -gt 0 ]; then
+  picker_rows=()
+  for row in "${existing[@]}"; do
+    IFS='|' read -r _socket_name session_name attached created panes <<<"$row"
+    status=$([ "$attached" = "1" ] && echo "attached" || echo "detached")
+    picker_rows+=("$(format_picker_row "$session_name" "$status" "$panes" "$(format_uptime "$created")")")
+  done
+
+  if ! pick="$(pick_one_tui \
+    "Resume an orca in $(shorten_path "$WORKDIR"), or start a new one?" \
+    "" \
+    "start a new one" \
+    "${picker_rows[@]}")"; then
+    echo "Cancelled"
+    exit 0
+  fi
+
+  if [ "$pick" != "NEW" ]; then
+    chosen="${existing[$((pick - 1))]}"
+    IFS='|' read -r socket_name session_name _attached _created _panes <<<"$chosen"
+    if $START_ARGS_PASSED; then
+      echo "Warning: start args are ignored when attaching to an existing instance"
+    fi
+    exec tmux -L "$socket_name" attach -t "$session_name"
+  fi
+fi
+
+SESSION="$(next_session_name "$WORKDIR")"
+# Per-instance dedicated tmux server: isolates orca from the user's main
+# tmux server so stop=kill-server gives a clean env on next start, and orca
+# never pollutes / inherits stale env from the user's long-lived server.
+SOCKET="$SESSION"
+TMUX_CMD="tmux -L $SOCKET"
 
 # --- Build worker labels (space-separated, bash 3.2 compat) ---
 WORKER_LABELS=""
@@ -206,7 +236,7 @@ launch_agent() {
 i=1
 for label in $WORKER_LABELS; do
   pane="$SESSION:main.${i}"
-  env_cmd="export ORCA=1 ORCA_ROLE=worker ORCA_PEER=${LEAD_LABEL} ORCA_WORKER_ID=${i} ORCA_ROOT=${WORKDIR}"
+  env_cmd="export ORCA=1 ORCA_ROLE=worker ORCA_PEER=${LEAD_LABEL} ORCA_WORKER_ID=${i} ORCA_ROOT=${WORKDIR} ORCA_SESSION=${SESSION}"
   [ -n "$WORKFLOW" ] && env_cmd="${env_cmd} ORCA_WORKFLOW=${WORKFLOW}"
   $TMUX_CMD send-keys -t "$pane" "$env_cmd" Enter
   launch_agent "$pane" "$WORKER_MODEL" "worker"
@@ -214,7 +244,7 @@ for label in $WORKER_LABELS; do
 done
 
 # --- Inject env + launch lead ---
-lead_env="export ORCA=1 ORCA_ROLE=lead ORCA_WORKERS=${WORKERS_CSV} ORCA_PEER=${FIRST_WORKER_LABEL} ORCA_ROOT=${WORKDIR}"
+lead_env="export ORCA=1 ORCA_ROLE=lead ORCA_WORKERS=${WORKERS_CSV} ORCA_PEER=${FIRST_WORKER_LABEL} ORCA_ROOT=${WORKDIR} ORCA_SESSION=${SESSION}"
 [ -n "$WORKFLOW" ] && lead_env="${lead_env} ORCA_WORKFLOW=${WORKFLOW}"
 $TMUX_CMD send-keys -t "$SESSION:main.0" "$lead_env" Enter
 launch_agent "$SESSION:main.0" "$LEAD_MODEL" "lead"

--- a/stop.sh
+++ b/stop.sh
@@ -1,84 +1,107 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Sanitize basename: tmux uses `.` and `:` as target separators
-# (session:window.pane), so dirs containing them break tmux targeting.
-SESSION="orca-$(basename "$(pwd)" | tr '.:' '--')"
-# Per-instance dedicated tmux server (D8): the server only owns this one
-# session, so killing the server is equivalent to killing the session and
-# also wipes the cached global env that would otherwise leak into the next
-# `orca` start. See docs/troubleshooting/tmux-server-stale-env.md.
-SOCKET="$SESSION"
-TMUX_CMD="tmux -L $SOCKET"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "$SCRIPT_DIR/_lib.sh"
 
-# Detect both targets:
-#   - dedicated: session on per-instance server (D8, current scheme)
-#   - legacy:   session on user's main tmux server (pre-D8 orphans, since
-#               nothing else can manage them after the upgrade)
-HAS_DEDICATED=false
-HAS_LEGACY=false
+CURRENT_CWD="$(pwd)"
+selected=()
 
-if $TMUX_CMD has-session -t "$SESSION" 2>/dev/null; then
-  HAS_DEDICATED=true
-fi
-if tmux has-session -t "$SESSION" 2>/dev/null; then
-  HAS_LEGACY=true
+resolve_targets() {
+  local target row id type socket_name name cwd _a _c _p
+  local seen_ids=() seen rc
+
+  for target in "$@"; do
+    rc=0
+    row=$(resolve_target_by_id_or_name "$target") || rc=$?
+    if [ "$rc" -eq 1 ]; then
+      echo "(run 'orca ps' to see available ids and names)" >&2
+      exit 1
+    fi
+    if [ "$rc" -eq 2 ]; then
+      echo "Ambiguous instance name '$target'; use the exact id from 'orca ps'" >&2
+      exit 1
+    fi
+
+    IFS='|' read -r type socket_name name _a _c _p cwd <<<"$row"
+    id=$(short_id "$type:$name:$cwd")
+    for seen in "${seen_ids[@]}"; do
+      [ "$seen" = "$id" ] && continue 2
+    done
+    selected+=("$row")
+    seen_ids+=("$id")
+  done
+}
+
+if [ "$#" -eq 0 ]; then
+  current_instances=()
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    current_instances+=("$row")
+  done < <(list_all_instances_in_cwd "$CURRENT_CWD" | sort -t '|' -k5,5nr)
+
+  if [ "${#current_instances[@]}" -eq 0 ]; then
+    echo "No orca instances found in $(shorten_path "$CURRENT_CWD")"
+    exit 0
+  fi
+
+  picker_rows=()
+  for row in "${current_instances[@]}"; do
+    IFS='|' read -r type socket_name name attached created panes cwd <<<"$row"
+    id=$(short_id "$type:$name:$cwd")
+    status=$([ "$attached" = "1" ] && echo "attached" || echo "detached")
+    picker_rows+=("$id  $(format_picker_row "$name" "$status" "$panes" "$(format_uptime "$created")")")
+  done
+
+  if ! picks="$(pick_many_tui \
+    "Stop which orcas?" \
+    "" \
+    "${picker_rows[@]}")"; then
+    echo "Cancelled"
+    exit 0
+  fi
+
+  if [ -z "$picks" ]; then
+    echo "No instances selected"
+    exit 0
+  fi
+
+  while IFS= read -r pick; do
+    [ -n "$pick" ] || continue
+    selected+=("${current_instances[$((pick - 1))]}")
+  done <<<"$picks"
+else
+  resolve_targets "$@"
 fi
 
-if ! $HAS_DEDICATED && ! $HAS_LEGACY; then
-  echo "Session '$SESSION' does not exist (neither dedicated nor legacy)"
-  exit 0
-fi
+summary=''
+for row in "${selected[@]}"; do
+  IFS='|' read -r type socket_name name attached created panes cwd <<<"$row"
+  label="$name"
+  if [ -n "$summary" ]; then
+    summary="${summary}, ${label}"
+  else
+    summary="$label"
+  fi
+done
 
-echo "Found:"
-if $HAS_DEDICATED; then
-  echo "  - dedicated server: $SESSION"
-  $TMUX_CMD list-panes -t "$SESSION" -F "      pane #{pane_index}: #{pane_current_command} (pid: #{pane_pid})"
-fi
-if $HAS_LEGACY; then
-  echo "  - main tmux (legacy, pre-D8): $SESSION"
-  tmux list-panes -t "$SESSION" -F "      pane #{pane_index}: #{pane_current_command} (pid: #{pane_pid})"
-fi
-
-echo ""
-read -rp "Stop all of the above? [y/N] " confirm
+echo "About to stop: $summary"
+read -rp "Proceed? [y/N] " confirm
 if [[ "$confirm" != [yY] ]]; then
   echo "Cancelled"
   exit 0
 fi
 
-# Kill all monitor processes for this session
-for pid_file in /tmp/orca-monitor-"${SESSION}"-*.pid; do
-  [ -f "$pid_file" ] || continue
-  kill "$(cat "$pid_file")" 2>/dev/null || true
-  rm -f "$pid_file"
+for row in "${selected[@]}"; do
+  IFS='|' read -r type socket_name name attached created panes cwd <<<"$row"
+  stop_instance "$type" "$socket_name" "$name" "$cwd"
+  case "$type" in
+    isolated)
+      echo "Stopped isolated instance: $name"
+      ;;
+    main-tmux)
+      echo "Stopped main-tmux session: $name"
+      ;;
+  esac
 done
-# Legacy single-pid monitor (pre-multi-worker)
-MONITOR_PID="/tmp/orca-monitor-${SESSION}.pid"
-if [ -f "$MONITOR_PID" ]; then
-  kill "$(cat "$MONITOR_PID")" 2>/dev/null || true
-  rm -f "$MONITOR_PID"
-fi
-
-# Clean up worktrees
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-if [ -x "$SCRIPT_DIR/orca-worktree.sh" ]; then
-  "$SCRIPT_DIR/orca-worktree.sh" clean 2>/dev/null || true
-fi
-
-# Clean up heartbeat state
-rm -rf .orca/heartbeat 2>/dev/null || true
-
-if $HAS_DEDICATED; then
-  # Kill the dedicated server (not just the session). This is what gives the
-  # next `orca` start a clean env — the server holds the cached -g environment.
-  $TMUX_CMD kill-server 2>/dev/null || true
-  echo "Stopped dedicated server for $SESSION (server killed, env cleared)"
-fi
-
-if $HAS_LEGACY; then
-  # Just kill the session, not the user's main tmux server (which may host
-  # other unrelated sessions).
-  tmux kill-session -t "$SESSION" 2>/dev/null || true
-  echo "Cleaned up legacy $SESSION on main tmux server"
-fi

--- a/stop.sh
+++ b/stop.sh
@@ -5,7 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=_lib.sh
 source "$SCRIPT_DIR/_lib.sh"
 
-CURRENT_CWD="$(pwd)"
+# Canonicalize: see start.sh for rationale (macOS /tmp -> /private/tmp).
+CURRENT_CWD=$(cd "$(pwd)" 2>/dev/null && pwd -P) || CURRENT_CWD="$(pwd)"
 selected=()
 
 resolve_targets() {

--- a/tests/picker_test.sh
+++ b/tests/picker_test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Regression tests for the TUI pickers (pick_one_tui / pick_many_tui).
+#
+# Drives the picker subprocess in an isolated tmux server, injects keys via
+# `send-keys`, captures the printed result. No new dependencies — tmux is
+# already required by orca itself.
+#
+# Usage: ./tests/picker_test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="${SCRIPT_DIR}/../_lib.sh"
+SOCK="picker-test-$$"
+SCRATCH="$(mktemp -d)"
+trap 'tmux -L "$SOCK" kill-server 2>/dev/null || true; rm -rf "$SCRATCH"' EXIT
+
+# Sanity: lib must be sourceable.
+# shellcheck source=../_lib.sh
+source "$LIB"
+
+PASS=0
+FAIL=0
+
+# Run a one-shot picker harness in tmux; inject keys; echo the captured output.
+# Args: <harness_body> [keys...]
+run_picker() {
+  local body="$1"; shift
+  local outfile="$SCRATCH/out"
+  local script="$SCRATCH/harness.sh"
+
+  cat > "$script" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+source "$LIB"
+$body
+EOF
+  chmod +x "$script"
+  rm -f "$outfile"
+
+  tmux -L "$SOCK" new-session -d -s t -x 100 -y 20 "$script > '$outfile' 2>&1; sleep 5"
+  sleep 0.4
+  while [ "$#" -gt 0 ]; do
+    tmux -L "$SOCK" send-keys -t t "$1"
+    shift
+    sleep 0.1
+  done
+  sleep 0.4
+  tmux -L "$SOCK" kill-session -t t 2>/dev/null || true
+  cat "$outfile" 2>/dev/null || true
+}
+
+assert_eq() {
+  local got="$1" want="$2" label="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok    %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n        want: %s\n        got:  %s\n' "$label" "$want" "$got"
+  fi
+}
+
+ONE_HARNESS='r=$(pick_one_tui "Pick:" "" "new" "row 1" "row 2" "row 3") || { echo "CANCELLED"; exit 0; }
+echo "RESULT: $r"'
+
+MANY_HARNESS='r=$(pick_many_tui "Pick many:" "" "row A" "row B" "row C") || { echo "CANCELLED"; exit 0; }
+echo "PICKED: $(echo "$r" | tr "\n" "," | sed "s/,$//")"'
+
+echo "pick_one_tui:"
+assert_eq "$(run_picker "$ONE_HARNESS" Down Enter)"           "RESULT: 2"   "Down + Enter -> row 2"
+assert_eq "$(run_picker "$ONE_HARNESS" Down Down Down Enter)" "RESULT: NEW" "Down x3 + Enter -> NEW (last entry)"
+assert_eq "$(run_picker "$ONE_HARNESS" j Enter)"              "RESULT: 2"   "j (vim down) + Enter"
+assert_eq "$(run_picker "$ONE_HARNESS" k Enter)"              "RESULT: NEW" "k (vim up) wraps to last"
+assert_eq "$(run_picker "$ONE_HARNESS" Up Enter)"             "RESULT: NEW" "Up wraps to last"
+assert_eq "$(run_picker "$ONE_HARNESS" q)"                    "CANCELLED"   "q cancels"
+
+echo
+echo "pick_many_tui:"
+assert_eq "$(run_picker "$MANY_HARNESS" Space Down Down Space Enter)" "PICKED: 1,3" "Space + nav + Space + Enter"
+assert_eq "$(run_picker "$MANY_HARNESS" Down Space Up Space Enter)"   "PICKED: 1,2" "nav around, multi-toggle"
+assert_eq "$(run_picker "$MANY_HARNESS" Enter)"                       "PICKED: "    "Enter with no selection -> empty"
+assert_eq "$(run_picker "$MANY_HARNESS" q)"                           "CANCELLED"   "q cancels"
+
+echo
+echo "Total: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## 概要

允许同一目录下多个 orca 实例并存，关闭 PLAN.md 中的 D7 / P0 项。

- **命名**：新实例统一带 `orca-<dir>-<YYYYMMDDhhmmss>` 后缀（同秒冲突 +1 秒）。老的 `orca-<dir>` session 仍被识别为合法的"第一个实例"。
- **start**：cwd 已有实例时弹 TUI 单选 picker（↑/↓ 或 j/k 移动、Enter 选择、q/Esc 取消，当前行天蓝色文字）。最后一项是"start a new one"。默认选中最近创建。
- **stop**：`orca stop` 不带参数时显示 cwd 内实例的 TUI 复选框 picker。`orca stop <id|name> [<id|name> ...]` 直接停指定目标，id/name 解析逻辑与 `orca rm` 一致。
- **ps**：输出按 cwd 分组，组内按 created 升序。
- **内部**：`_lib.sh` 新增共享辅助函数（实例枚举、TUI picker、id/name 解析、生命周期清理）。`rm.sh` 重构为调用这些 helper。心跳目录改为按 session namespace（`.orca/heartbeat/<session>/`），避免多实例互踩。TUI picker UI 走 `/dev/tty`、结果走保留的 FD 5，从而能在 `$(...)` capture 中正常工作。
- **测试**：`tests/picker_test.sh` 用隔离的 tmux server + send-keys 驱动两个 picker，10 个用例覆盖箭头/vim 键、wrap-around、cancel、多选切换。
- **文档**：AGENTS.md 加了 worktree 操作规范（HEAD-affecting 命令优先用 `git -C <path>`，避免 `cd <worktree> && git ...` 改错 HEAD）。
- **修复**：canonicalize cwd（`cd && pwd -P`）以处理 macOS `/tmp -> /private/tmp` 这类 symlink 路径下 cwd 字符串比对失败的问题。

## 兼容性

| 项目 | 状态 |
|---|---|
| `orca ps` | ✅ 完全兼容（legacy `orca-<dir>` 仍出现，只是按 cwd 分组） |
| `orca rm` | ✅ 完全兼容（id/name 匹配、ambiguity picker、dead-socket fast path 保留） |
| Monitor PID 清理 | ✅ `cleanup_monitor_pids` 同时清理 worker glob `<session>-*.pid` 和 legacy 单文件 |
| `orca stop` 无参 | ⚠️ UX 变化：旧"直接停 cwd 那一个" → 新"弹 picker"，单实例下也要按一次 Enter |
| 心跳目录 | ⚠️ 旧扁平 `.orca/heartbeat/<worker_id>` 不被新 stop 清理（新 namespaced 结构）；遗留几字节孤儿，无功能影响 |
| Worktree 自动清理 | ❌ 已知回归：新 stop 不再 `orca-worktree clean`（intentional，兄弟实例可能共享 worktree dir） |

## 测试结果（全部通过）

- [x] `./tests/picker_test.sh` → **10 passed, 0 failed**
- [x] 空 dir 下 `orca` 直接起 timestamped 实例（不弹 picker）
- [x] 已有实例的 dir 下 `orca` 弹 picker；Enter 默认 attach 最近创建；最后一项 `start a new one` 起第 2 实例
- [x] `orca ps` 按 cwd 分组、组内按 created 升序、PANES 列正确显示
- [x] `orca stop` 无参 → TUI 复选框 picker；Space 多选 + Enter 提交后正确停掉
- [x] `orca stop <name>` 直停指定实例，无 picker
- [x] `orca rm <name>` 仍工作（走共享 helper；ambiguity picker 用 `pick_one`）
- [x] Pre-feature 的 `orca-<dir>` session（无时间戳）在 picker / ps / stop / rm 中均可见
- [x] TUI picker cancel 路径：q 和 Esc 都能干净恢复终端
- [x] `.orca/worktree/` 在 `orca stop` 后不再被自动清理（intentional —— 兄弟实例可能共享）

🤖 Generated with [Claude Code](https://claude.com/claude-code)