### PR TITLE
docs: note iTerm2 mouse-reporting toggle in troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Standard tmux bindings (prefix is `Ctrl+B`):
 - **Codex macOS sandbox**: openai/codex#10390 — using `--sandbox danger-full-access -a on-request`
 - **Shift+Enter in Codex (Ghostty + tmux)**: Codex 0.121 doesn't negotiate the Kitty keyboard protocol under tmux, so Ghostty's Shift+Enter doesn't reach it. Use Option+Enter for newline, or remap Shift+Enter in Ghostty config — see [docs/troubleshooting/ghostty-codex-shift-enter.md](docs/troubleshooting/ghostty-codex-shift-enter.md).
 - **Cmd+Click links in Ghostty/Zed + tmux**: tmux `mouse on` consumes Cmd+Click before the terminal can turn it into a hyperlink jump. Use **Shift+Cmd+Click** instead, or switch to iTerm2/WezTerm — see [docs/troubleshooting/tmux-osc8-hyperlinks.md](docs/troubleshooting/tmux-osc8-hyperlinks.md).
+- **iTerm2 mouse stops working in panes**: if clicks don't switch panes and the scroll wheel scrolls the whole window instead of one pane, open Settings → Profiles → *current profile* → Terminal and toggle **Enable mouse reporting** — check it if unchecked, or uncheck and re-check it if it already looks enabled (the runtime state can desync from the checkbox). Not an orca bug — happens in any tmux session.
 - **Heartbeat is not real-time**: idle notifications surface on lead's next tool use, not instantly (see [docs/design/heartbeat.md](docs/design/heartbeat.md))
 
 ## License

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -84,6 +84,7 @@ tmux 标准绑定（prefix 是 `Ctrl+B`）：
 - **Codex macOS 沙箱**：openai/codex#10390 — 使用 `--sandbox danger-full-access -a on-request`
 - **Codex 内 Shift+Enter（Ghostty + tmux）**：Codex 0.121 在 tmux 下不协商 Kitty 键盘协议，Ghostty 的 Shift+Enter 编码到不了它。换行用 Option+Enter，或在 Ghostty config 里 remap Shift+Enter — 见 [docs/troubleshooting/ghostty-codex-shift-enter.md](docs/troubleshooting/ghostty-codex-shift-enter.md)。
 - **Ghostty/Zed + tmux 内 Cmd+Click 跳转链接**：tmux `mouse on` 在终端转成 hyperlink 跳转之前就消费了 Cmd+Click。改用 **Shift+Cmd+Click**，或换 iTerm2/WezTerm — 见 [docs/troubleshooting/tmux-osc8-hyperlinks.md](docs/troubleshooting/tmux-osc8-hyperlinks.md)。
+- **iTerm2 内鼠标失效（点击切不动 pane / 滚轮整屏滚动）**：打开 iTerm2 Settings → Profiles → *当前 profile* → Terminal，切换 **Enable mouse reporting** —— 没勾的勾上；已经勾着的也要取消再重新勾一次（运行时状态会和复选框脱节）。不是 orca 的 bug，任何 tmux session 都会中招。
 - **心跳非实时**：idle 通知在 lead 下次 tool 调用时才显示，非即时推送（见 [docs/design/heartbeat.md](docs/design/heartbeat.md)）
 
 ## License


### PR DESCRIPTION
## Summary
- Add a Known Limitations entry to `README.md` and `README.zh-CN.md` covering the case where iTerm2 panes stop responding to clicks and the scroll wheel scrolls the whole window instead of one pane.
- Fix is to toggle Settings → Profiles → *current profile* → Terminal → **Enable mouse reporting**. If the box already looks checked, uncheck and re-check it — the runtime state can desync from the checkbox.
- Not an orca bug (any tmux session hits this), but the first-time symptom looks like orca is broken, so worth a one-liner in troubleshooting.

## Test plan
- [ ] Render both READMEs on GitHub and confirm the new bullet sits next to the other tmux/mouse entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)