### PR TITLE
feat(worktree): auto-add .orca/ to host repo .gitignore on create

### DIFF
--- a/orca-worktree.sh
+++ b/orca-worktree.sh
@@ -31,6 +31,26 @@ validate_slug() {
   fi
 }
 
+# Idempotent: append `.orca/` to the host repo's .gitignore if missing.
+# Matches `.orca` or `.orca/` as a standalone line so we don't double-write
+# when the user already excluded it. Writes to stderr (stdout is reserved
+# for the `create` worktree-path return value consumed by callers).
+ensure_gitignore_orca() {
+  local repo_root gitignore
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 0
+  gitignore="$repo_root/.gitignore"
+  if [ -f "$gitignore" ] && grep -qE '^\.orca/?$' "$gitignore"; then
+    return 0
+  fi
+  # Ensure existing file ends with a newline before appending, otherwise the
+  # new entry concatenates onto the previous last line.
+  if [ -f "$gitignore" ] && [ -n "$(tail -c1 "$gitignore" 2>/dev/null)" ]; then
+    printf '\n' >> "$gitignore"
+  fi
+  printf '.orca/\n' >> "$gitignore"
+  echo "Added .orca/ to $gitignore" >&2
+}
+
 cmd="${1:-}"
 
 case "$cmd" in
@@ -39,6 +59,7 @@ case "$cmd" in
     validate_slug "$id"
     dir="${ORCA_DIR}/${id}"
     branch="orca-${id}"
+    ensure_gitignore_orca
     mkdir -p "$(dirname "$dir")"
     git worktree add "$dir" -b "$branch"
     echo "$dir"


### PR DESCRIPTION
## Summary

- `orca-worktree create` now appends `.orca/` to the host repo's `.gitignore` if missing, before running `git worktree add`.
- Idempotent: matches `.orca` or `.orca/` as a standalone line; tolerates a missing trailing newline (prepends `\n` first); silently no-ops outside a git repo.
- Logs to stderr so the `echo "$dir"` stdout contract consumed by callers stays intact.

## Why

Worktrees land under `.orca/worktree/<slug>`. Without a matching `.gitignore` entry the host repo's `git status` lists an untracked `.orca/...` directory after the first dispatch. We previously discussed adding this on `orca init`; since there is no `init` subcommand, doing it on `create` ties the side effect to the moment the dirty path actually appears, with no new surface area for the user to remember.

## Test plan

- [x] No `.gitignore` → file created with `.orca/`
- [x] `.gitignore` already contains `.orca/` → no-op (no duplicate)
- [x] `.gitignore` exists but missing trailing newline → newline prepended, `.orca/` appended on its own line
- [x] Stdout still emits only the worktree path (callers like `orca-code` workflow capture `$(orca-worktree create ...)`)