### PR TITLE
docs: competitor analysis (OMC / OMX / ctx) and Orca evolution proposal

### DIFF
--- a/docs/research/competitor-analysis/README.md
+++ b/docs/research/competitor-analysis/README.md
@@ -1,0 +1,48 @@
+# 竞品/参考项目对比分析
+
+本目录归档 Orca 与同类项目的对比分析，用于回答：
+
+- Orca 的入口范式是否合理？
+- Orca 的上下文持续性应该怎么补？
+- Orca 的差异化定位在哪里？
+
+## 文档清单
+
+| 文件 | 内容 | 状态 |
+|---|---|---|
+| [comparison-matrix.md](./comparison-matrix.md) | 四方对比矩阵（含 UX 维度） | ✅ 主框架完成，部分待 worker 实测 |
+| [ux-issues.md](./ux-issues.md) | Nick 反馈拆解 + UX 问题清单 | ✅ |
+| [omc-deep-dive.md](./omc-deep-dive.md) | OMC（oh-my-claudecode）深度分析 | 🟡 骨架，待 worker 填充 |
+| [omx-deep-dive.md](./omx-deep-dive.md) | OMX（oh-my-codex）深度分析 | 🟡 骨架，待 worker 填充 |
+| [ctx-deep-dive.md](./ctx-deep-dive.md) | ctx（dchu917/ctx）深度分析 | ✅ worker 报告整理 |
+| [orca-evolution-proposal.md](./orca-evolution-proposal.md) | Orca 改造方向建议 | ✅ |
+
+## 对比对象
+
+| 项目 | 仓库 | 定位 |
+|---|---|---|
+| **Orca** | 本仓库 | tmux 多 agent 编排器 |
+| **OMC** | [Yeachan-Heo/oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | Claude Code 多 agent plugin |
+| **OMX** | [staticpayload/oh-my-codex](https://github.com/staticpayload/oh-my-codex) | Codex CLI 编排层 |
+| **ctx** | [dchu917/ctx](https://github.com/dchu917/ctx) | 本地上下文持续化 |
+
+> 注：另有 [stablyai/orca](https://github.com/stablyai/orca) 的对比已在 [`../stably-orca-compare.md`](../stably-orca-compare.md)，定位是 Electron 桌面端，与本目录的 CLI/Agent-plugin 维度不同，单独存档。
+
+## 一句话结论
+
+| 项目 | 学什么 | 怎么学 |
+|---|---|---|
+| **OMC** | Agent 内入口、按需 spawn pane、低门槛安装 | 把 `orca` 主入口下沉到 cc/codex 内的 skill；tmux 按需而非起手 |
+| **OMX** | 任务队列、worker claim 模型、`doctor` 自检命令 | Phase 2 引入队列模型，避免 lead 直接硬指派 |
+| **ctx** | workstream 数据模型、绑定表、增量拉取、快照分支、pin/exclude | shell + sqlite3 CLI 自研（不依赖 Python） |
+| **不学** | OMC 的 19 unified agents 库；ctx 的 Web UI；OMX 的强 Codex 耦合 | 保持 Orca 异构 agent 编排的差异化定位 |
+
+详见 [orca-evolution-proposal.md](./orca-evolution-proposal.md)。
+
+## 调研方法说明
+
+- WebFetch / WebSearch 公开材料
+- 部分项目源码 git clone 到 `/tmp/` 静态阅读
+- 不在范围：UI 截图、企业版功能、商业模型
+- Attribution：仅以「文件路径 + 行号」形式引用，不复制源码
+- 时间戳：2026-04-22

--- a/docs/research/competitor-analysis/comparison-matrix.md
+++ b/docs/research/competitor-analysis/comparison-matrix.md
@@ -1,0 +1,240 @@
+# 四方对比矩阵
+
+> 对比对象：Orca（当前）/ OMC / OMX / ctx
+> 时间：2026-04-22
+
+## 1. 产品定位
+
+| 维度 | Orca（当前） | OMC | OMX | ctx |
+|---|---|---|---|---|
+| 一句话定位 | tmux 多 agent 编排器 | Claude Code 多 agent plugin | Codex CLI 编排层 | 本地上下文持续化 |
+| 核心解决问题 | Lead 调度 Worker 并行 | Claude Code 内编排 native Team + 19 个主 agent | Codex 内 TDD/plan/review workflow | 跨会话上下文恢复、防漂移 |
+| 设计哲学 | shell-only orchestrator | "Don't learn CC, just use OMC" | "oh-my-zsh for Codex" | local-first, no API key |
+| 主语 | "工头-工人" 流水线 | Agent 团队 | 结构化 workflow | workstream（工作流） |
+| 差异化 | 异构 agent + 弱研发流程 + 多 worktree | 19 个 unified agents + Team/native+tmux 双 runtime | 队列 + 持久 state | 上下文绑定 + 增量拉取 |
+
+---
+
+## 2. 入口与启动方式（Nick 最关心）
+
+| 维度 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| 入口位置 | **shell 外**（`orca` 命令） | **Agent 内**（`/autopilot`） | **Agent 内**（`$ultrawork`） | **Agent 内**（`/ctx`） |
+| 启动顺序 | 先 orca → 再装 cc/codex | 先开 cc → 再 `/autopilot` | 先开 codex → 再 `$ultrawork` | 先开 cc/codex → 再 `/ctx` |
+| 默认是否拉 tmux | **是**（强制） | `/team` 否，`omc team` 是；`omc` 主 CLI 的默认 tmux 包装方向在 Issue #716 关闭后进入文档口径，但源码侧本轮未完全验证 | 否（team worker 才用 tmux） | 否（与 tmux 无关） |
+| 默认布局 | 多 pane（lead + N worker） | 单 cc 会话 | 单 codex 会话 | 单会话 |
+| 安装方式 | `install.sh` 写 hook + skill | `/plugin install` 原生 plugin | npm + `omx setup` | `setup.sh` 或 `curl \| bash` |
+| 安装步骤数 | 1（脚本一键）+ 多步骤副作用 | 2（marketplace add + plugin install） | 3（npm + setup + doctor） | 1-3（视方式） |
+
+---
+
+## 3. 使用者视角 —— 上手难度
+
+> 单位：从「装好工具」到「完成第一次有价值任务」需要的步数和心智负担
+
+| 维度 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| **首次价值前置步骤** | 1. `orca` 起 tmux<br>2. 理解 lead/worker pane<br>3. 主 pane 输入任务<br>4. lead 自行调度 worker | 1. `/autopilot "任务"`<br>（一句话开工） | 1. `omx setup`<br>2. `omx doctor`<br>3. `$ultrawork "任务"` | 1. `/ctx start <name>`<br>2. 正常对话<br>3. `/ctx pull` 抓 transcript |
+| **必备前置概念** | tmux pane / worktree / bridge / lead-worker 协议 | （几乎无） | session / queue / worker 类型 | workstream / session / entry / source binding |
+| **主观上手难度** | 高 | 极低 | 中 | 中 |
+| **首次成功体验时长**（估算） | 5-15 min | < 1 min | 3-5 min | 2-3 min |
+| **是否需要看文档** | 必须 | 不需要 | 推荐 | 推荐 |
+| **失败时的错误反馈** | tmux/bash 报错（用户要懂 tmux） | Agent 内自然语言 | `omx doctor` 自检 | shell 错 + Agent 重提示 |
+
+**解读**：OMC 是降维打击。它把"零学习"做到了极致：进 cc 直接 `/autopilot`。Orca 的入口前置成本是其他三家的好几倍。
+
+---
+
+## 4. 使用者视角 —— 日常使用顺畅性
+
+> 单位：高频操作（每天可能 10-50 次）的摩擦点
+
+| 操作 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| 启动新任务 | 切到 lead pane → 输入 | 在 cc 内 `/autopilot` | 在 codex 内 `$ultrawork` | 在 cc/codex 内 `/ctx start` |
+| 查看 worker 进度 | `tmux switch` 或主 pane 看 PreToolUse 通知 | cc 内自动汇报 | 队列状态查询命令 | 不涉及 |
+| 中断 worker | 切到 worker pane → Ctrl+C 或回到 lead message | 自然语言中断 | `omx team kill` | 不涉及 |
+| 切换 agent 类型 | 重启 worker pane | OMC 自动选 | `omx team spawn <type>` | 不涉及 |
+| 多任务并行 | 必须开多 pane | 显式 `/team N:agent` | `omx team queue` | 不涉及 |
+| 单 pane 简单提问 | **做不到**（要么用 orca 要么不用） | 直接对话即可 | 直接对话即可 | 不影响 |
+| 退出/收尾 | `stop.sh` 杀 session | 关 cc 即可 | 关 codex 即可 | 关 Agent 即可 |
+| 重启电脑后恢复 | 全部失去 | 部分（cc 自身能力） | 部分 | **完整恢复**（DB） |
+
+**解读**：Nick 的"突然不想用了"主要源于这一栏：**"单 pane 简单提问"在 Orca 里做不到**。OMC/OMX 是"日常用 cc/codex，需要时调用编排"，Orca 是"用 orca 就被锁死在 tmux 里"。
+
+---
+
+## 5. 使用者视角 —— 可观测性
+
+> 用户能看到 Agent 在做什么、任务进展如何
+
+| 维度 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| 实时输出 | tmux pane 直接显示（多 pane 要切） | cc 内嵌显示 | codex 内嵌显示 + tmux pane | 不涉及实时 |
+| 进度通知 | PreToolUse hook 在 lead 显示 | cc 原生 | `omx hud` 仪表盘 | 不涉及 |
+| 全局视图 | `orca ps` 列实例 | `omc team status <team-name>`；in-session `/team status` 未直接验证 | `omx hud` / `omx team status` / `omx team inbox` | Web UI 时间线 |
+| 历史追溯 | scrollback（pane 死即丢） | cc 自身历史 | session 持久化 | **SQLite 全文搜索** |
+| 跨 worker 视图 | 必须切 pane | OMC 内聚合 | 队列 inbox | 不涉及 |
+| 错误定位 | scrollback grep | cc 内 | `omx doctor` | 不涉及 |
+| 第三方查看 | `tmux attach` | 难 | `omx hud` | Web UI（loopback） |
+
+**解读**：Orca 在"实时"上有 tmux 优势（每个 pane 就是直播），但**"持续追溯"完全空白**——这是 ctx 最大的补位点。OMX 的 `omx hud` 是个有意思的中间态：仪表盘聚合状态。
+
+---
+
+## 6. 使用者视角 —— 可介入性
+
+> 任务跑偏、需要纠偏或临时修改时的路径
+
+| 维度 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| 介入入口 | 切 worker pane 直接打字 / 回 lead pane 让 lead 转发 | cc 内自然语言 | codex 内自然语言 / `omx team` 命令 | 不涉及 |
+| 工头介入 vs 用户直接介入 | 都行（用户偏好"工头介入"，见 Nick 反馈） | 自然由 Claude 主导 | codex 主导 | 不涉及 |
+| 危险操作授权 | **worker pane 自己处理**（Codex `rm -rf` 弹确认） | cc 自身机制 | codex 自身机制 | 不涉及 |
+| 暂停 / 续跑 | 杀 pane / 重起 pane（丢上下文） | cc 原生支持 | session 持久化 | 不涉及 |
+| 改主意（任务变了） | 重新 message lead | 自然语言重述 | 自然语言重述 | 不涉及 |
+| 局部回滚 | 无 | 无 | 未验证到内建 session 回滚；当前更像靠持久 state + operator 手动修复 | branch 快照可回 |
+
+**解读**：Nick 说"得让工头来介入啊，流水线工人那边不能随便介入的"——这是**协作流程偏好**，不是技术限制。Orca 实际两条路都通，但默认范式应明确"工头优先介入"，避免用户养成"跳进 worker pane 抢键盘"的反模式。
+
+---
+
+## 7. 使用者视角 —— 自动互相沟通的连续性
+
+> 多 Agent 协作时，沟通是否流畅、是否需要人工拼接
+
+| 维度 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| 通信通道 | tmux-bridge（pane 间发消息） | OMC 内部协议 | 队列 + state | 无（单 agent）|
+| 通信触发 | 显式调用 bridge 命令 | 自动路由 | 队列 claim | - |
+| 通信延迟 | 1-3 秒（PreToolUse hook 心跳） | 即时 | 队列轮询 | - |
+| 上下文传递方式 | 文本消息体 / 文件路径 | 内部对象 | session state | - |
+| 大消息处理 | 写文件 + 路径传递 | 内部 | 内部 | - |
+| 跨 Agent 一致性 | 无（lead 自己维护） | OMC 维护 | OMX 维护 | - |
+| 通信日志 | tmux scrollback | OMC 历史 | session 持久 | - |
+| 通信失败重试 | 无（要 lead 看 read 结果） | 自动 | 队列重试 | - |
+| 异步任务 | 不支持（lead 等 worker） | 部分支持：native Team API + tmux CLI runtime | **核心能力**（队列/claim） | - |
+| 中断恢复 | 不支持（pane 死即丢） | 部分：dead worker 检测 + restart 设计，但 CLI team 可直接 fail fast | 部分：stale lease 可见，但无自动 requeue | - |
+
+**解读**：Orca 的 tmux-bridge 是**显式同步通信**，OMX 的队列模型是**异步任务编排**。两者哲学不同：
+- Orca：lead 是"项目经理"，直接和 worker 对话
+- OMX：lead 是"任务发布者"，把任务扔进队列，worker 自取
+
+Orca 的痛点：lead 必须 `read` worker pane 才知道结果，间歇性轮询，**没有事件驱动**。`PreToolUse` hook 是个心跳但只能告知"idle"，不能告知"结果就绪"。
+
+---
+
+## 8. 多 Agent / 多 Worker 模式
+
+| 维度 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| Worker spawn 时机 | 起手即建 | **按需**（`/team` 显式） | **按需**（`omx team spawn/queue`） | 不涉及 |
+| Worker 类型 | 同质（lead + worker） | 19 个主 agent + 兼容 alias；native Team 与 tmux worker 并存 | architect / executor / reviewer 等固定角色 | 不涉及 |
+| 任务分发 | lead 直接 message | `/team` 智能路由 | 队列 claim 模型 | 不涉及 |
+| 跨 Agent | Claude + Codex pane 平等 | Claude 主，可 delegate Codex/Gemini | Codex 主 | Claude + Codex 都支持 |
+| Worker 死亡 | 用户手动 stop | 任务完成自动死 | 任务完成自动死 | 不涉及 |
+| 资源占用 | 起手就占满 | 按需 | 按需 | - |
+
+---
+
+## 9. 上下文与持续性（worker 报告核心）
+
+| 维度 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| 上下文存储 | **无**（pane scrollback 即丢） | 内存 + 部分持久化 | 持久 state + memory | **SQLite 三层模型** |
+| 数据模型 | 无 | `.omc/` 状态文件 + Team config/event/heartbeat/runtime snapshot | `.omx/` JSON 文件族（tasks/reviews/inbox/team/memory/ledger） | `workstream/session/entry` |
+| 跨会话恢复 | 不支持 | 部分 | 支持 | **核心能力** |
+| Transcript 绑定 | 无 | 无 | 无 | **`session_source_link`** |
+| 增量拉取 | 无 | 无 | 无 | **`message_count` delta** |
+| 分支语义 | git worktree 物理隔离 | 无 | 无 | **快照分支不共享未来绑定** |
+| 搜索 | 无 | 会话/Team API 与 HUD 辅助，可观测性强于检索 | `omx explore index` | **SQLite FTS5** |
+| 负载控制（pin/exclude） | 无 | 无 | 无 | **支持** |
+
+---
+
+## 10. 集成机制
+
+| 维度 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| Hooks | `PreToolUse` 通知 lead | `UserPromptSubmit` / `SessionStart` / `PreToolUse` / `PostToolUse` / `Stop` 等完整钩子栈 | `SessionStart` / `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop` 预设包 | 几乎不用 hooks |
+| Skill | shared `orca` skill | 19 主 agent + 36 skill（另有兼容 alias） | TDD/plan/review skill | `/ctx`、`ctx-resume`、`branch` |
+| Slash command | `/orca` | `/setup` `/autopilot` `/team` | `$ultrawork` 等 | `/ctx` `/ctx resume` `/ctx branch` |
+| 通信通道 | tmux-bridge（pane 间） | Claude Code 内部 | Codex 内部 + tmux | shell + SQLite |
+| Codex 集成 | tmux pane | `omc team N:codex` 启真实 Codex CLI pane（不是一次性 `--no-interactive`） | 原生 | skill alias |
+
+---
+
+## 11. 技术栈与依赖
+
+| 维度 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| 主语言 | Bash | TypeScript / Node | TypeScript / Node + 少量 Rust helper | **Python**（86%） |
+| 运行时依赖 | tmux + bash | Node + Claude Code | Node + Codex CLI | Python 3.9+ + SQLite FTS5 |
+| 第三方包 | 无 | npm | npm | 标准库 only |
+| 数据库 | 无 | 无中心数据库，repo/worktree 状态文件 + 可选集中 `OMC_STATE_DIR` | 无数据库，repo-local `.omx/` JSON | SQLite (`~/.contextfun/context.db`) |
+| 安装复杂度 | 中（install.sh 多步） | 低（plugin 一键） | 中（npm + setup + doctor） | 中 |
+| 隐私边界 | 全本地 | 走 Claude Code | 走 Codex | 全本地，loopback only |
+
+---
+
+## 12. License & 维护
+
+| 维度 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| License | MIT | MIT | MIT | MIT |
+| Bus factor | 你 + Claude | Yeachan-Heo 主导 | scalarian 主导 | 单作者（dchu917） |
+| 活跃度 | - | 高（2026-04 仍在高频更新） | 中（2026-02 初发，2026-04-01 集中冲刺 v2） | 高（68 commits, 2026-04 密集） |
+| API 稳定性 | - | 中 | 中 | 中（项目年轻） |
+
+---
+
+## 13. 综合评分（主观，1-5 分）
+
+| 维度 | Orca | OMC | OMX | ctx |
+|---|---|---|---|---|
+| 上手难度（5=最易） | 2 | 5 | 3 | 4 |
+| 日常顺畅性 | 2 | 5 | 4 | - |
+| 可观测性 | 3 | 4 | 4 | 5 |
+| 可介入性 | 4 | 4 | 4 | - |
+| 通信连续性 | 2 | 4 | 5 | - |
+| 上下文持续性 | 1 | 3 | 4 | 5 |
+| 多 Agent 编排 | 4 | 5 | 4 | - |
+| 安装/维护 | 3 | 4 | 3 | 3 |
+| 总分（满分 40） | 21 | 34 | 27 | - |
+
+> 说明：ctx 不在多 agent 维度参与评分。Orca 的"多 agent 编排" 4 分是因为它确实把 lead/worker 跑通了，但被入口范式拖累。
+
+---
+
+## 14. 一句话差异化
+
+| 项目 | 一句话 |
+|---|---|
+| **Orca** | "我能让 Claude 和 Codex 在 tmux 里同时开工，但你得先学会 tmux" |
+| **OMC** | "你在 cc 里说一句 `/autopilot`，剩下的不用管" |
+| **OMX** | "Codex CLI 的 oh-my-zsh，TDD/plan/review 一条命令搞定" |
+| **ctx** | "你的 cc 和 codex 对话不会再丢了，还能搜、能分支、能恢复" |
+
+---
+
+## 待 worker 补充的细节
+
+以下维度已由 worker 通过源码/文档补齐：
+
+- [x] OMC `omc team status <team-name>` 实际存在；in-session `/team status` 仍未直接验证
+- [x] OMX `omx hud` 文本格式已由 `renderHud()` 源码确认
+- [x] OMC 当前主 catalog 已确认不是 32，而是 19 个 unified agents（另有兼容 alias）
+- [x] OMX 队列模型 API：`spawn/queue/claim/heartbeat/complete/review/inbox/logs/await`
+- [x] OMC/OMX 的 hook 注册位置已确认
+- [x] OMC setup 需要 `/setup` 或 `omc setup`，不是“完全零配置无 setup”
+- [x] OMC/OMX 的 License 已确认均为 MIT
+- [ ] OMC/OMX 中断恢复未做二进制级实机跑通，只完成源码核实
+
+## 修正记录
+
+- 把 OMC 的“32 specialists”修正为“当前 runtime 主 catalog 为 19 个 unified agents”；32 更像旧 tiered/内部文档口径，不是现行事实。
+- 把 OMC 的“`/team status`（推测）”修正为：`omc team status <team-name>` 已确认存在，in-session `/team status` 仍未直接验证。
+- 把 OMX 的“Async Claude Code delegation”从现有能力中移除：README/About 文案仍保留旧表述，但 FAQ 与架构文档明确说明 v2 已不再是 Claude bridge。
+- 把 OMX 的状态存储从“session-based/未明”修正为“repo-local `.omx/` JSON 文件族”。
+- 把 OMX 的“session 回滚（推测）”修正为“未验证到内建回滚，当前更像持久 state + operator 手动修复”。
+- 把 Orca 的 License 从“MIT（推测）”修正为仓库 `LICENSE` 已确认的 MIT。

--- a/docs/research/competitor-analysis/ctx-deep-dive.md
+++ b/docs/research/competitor-analysis/ctx-deep-dive.md
@@ -1,0 +1,576 @@
+# ctx 对 Orca 的借鉴价值分析
+
+分析日期：2026-04-22  
+目标仓库：<https://github.com/dchu917/ctx>
+
+## 结论先行
+
+### 推荐
+
+- **推荐借鉴 ctx 的“绑定 + 增量拉取 + 快照分支”设计，而不是直接依赖 ctx。**
+- **推荐优先移植数据模型和语义，不推荐原样移植 Python 运行时和 skill 结构。**
+- **推荐 Orca 先做 CLI/SQLite 的最小闭环，再决定要不要补 Web UI。**
+
+### 不推荐
+
+- **不推荐让 Orca 直接依赖 ctx 作为运行时核心。**
+  - 原因不是 ctx 做得差，而是它的产品边界和 Orca 不同：ctx 面向 Claude/Codex 单 agent 会话恢复；Orca 面向 tmux pane、多 worker、git worktree、多路通信。
+  - 直接依赖会把 Orca 从“shell-only 编排器”拉向“Python 本地应用 + skills 发行物”，哲学和安装面都会变。
+
+### 需讨论
+
+- Orca 是否愿意接受一个**可选**的 Python 子系统，还是坚持 shell + `sqlite3` CLI 实现。
+- Orca 的“上下文源”是否只接 Claude/Codex transcript，还是把 **tmux pane 通信日志**作为第一公民。
+- 是否要做 ctx 那样的本地 Web 浏览器；我认为应放在 Phase 2，而不是首批能力。
+
+---
+
+## 1. 核心机制
+
+## 1.1 workstream 数据模型
+
+ctx 的核心数据库是本地 SQLite，默认路径是 `~/.contextfun/context.db`，也支持通过 `ctx_DB` / `CONTEXTFUN_DB` 覆盖。[`contextfun/cli.py:15-21`](file:///tmp/ctx-analysis/contextfun/cli.py)。
+
+主表结构：
+
+- `workstream`
+  - `slug` / `title` / `description` / `tags` / `workspace` / `metadata`
+- `session`
+  - 归属 `workstream_id`
+  - 记录 `agent` / `workspace` / `metadata`
+- `entry`
+  - 归属 `session_id`
+  - 核心字段是 `type`、`content`、`extras`
+- `ctx_meta`
+  - 保存索引版本等元信息
+- `workstream_source_link`
+  - 旧层级绑定：workstream -> 外部 transcript
+- `session_source_link`
+  - 当前核心绑定：session -> 外部 transcript
+
+证据：[`contextfun/cli.py:47-133`](file:///tmp/ctx-analysis/contextfun/cli.py)
+
+我认为这里最值得 Orca 借鉴的是两个点：
+
+- **上下文不是平铺日志，而是 `workstream -> session -> entry` 三层。**
+- **外部 transcript 绑定单独建表，而不是直接塞进 entry。**
+
+这让 ctx 能同时解决“保存内容”和“追踪来源”两件事。
+
+## 1.2 entry 结构
+
+`entry` 的正文在 `content`，扩展属性在 `extras`。其中 `extras.load_behavior` 支持：
+
+- `default`
+- `pin`
+- `exclude`
+
+被 `exclude` 的 entry 仍然保留、可搜索，但不会继续进入未来的 load pack；`pin` 会强制保留。[`contextfun/cli.py:1131-1218`](file:///tmp/ctx-analysis/contextfun/cli.py)
+
+这套设计对 Orca 很有价值，因为 worker 报告、lead 调度、工具输出的信噪比差异非常大。Orca 完全可以复用这套“保留但不喂回模型”的语义。
+
+## 1.3 transcript binding 如何工作
+
+### transcript 来源路径
+
+ctx 直接扫描本地 transcript：
+
+- Codex: `~/.codex/sessions`
+- Claude: `~/.claude/projects`
+
+支持 `CODEX_HOME` / `CLAUDE_HOME` 覆盖。[`scripts/ctx_cmd.py:2016-2021`](file:///tmp/ctx-analysis/scripts/ctx_cmd.py)
+
+### 如何定位外部会话
+
+ctx 会从 transcript 文件内容或路径中提取 `external_session_id`：
+
+- Codex 读 `id` / `sessionId` / `session_id`
+- Claude 读 `sessionId`
+- 兜底用文件名或父目录里的 UUID
+
+证据：[`scripts/ctx_cmd.py:1875-1937`](file:///tmp/ctx-analysis/scripts/ctx_cmd.py)
+
+### 如何判断“当前会话”
+
+ctx 先读进程环境变量：
+
+- Codex: `CODEX_THREAD_ID` / `CODEX_SESSION_ID`
+- Claude: `CLAUDE_THREAD_ID` / `CLAUDE_SESSION_ID` / `CLAUDE_CONVERSATION_ID`
+
+再去本地 transcript 根目录里按 `external_session_id` 反查文件。[`scripts/ctx_cmd.py:2055-2085`](file:///tmp/ctx-analysis/scripts/ctx_cmd.py)
+
+### workspace 过滤
+
+ctx 不只靠最新文件时间，还会尝试从 transcript 头部抽取 `cwd` / `workspace`，优先匹配当前 repo 的 transcript。[`scripts/ctx_cmd.py:1940-2043`](file:///tmp/ctx-analysis/scripts/ctx_cmd.py)
+
+这是一个非常关键的实现细节：**它不是“最新会话”，而是“当前仓库里最像当前会话的 transcript”。**
+
+### 增量拉取
+
+绑定信息存到 `session_source_link`：
+
+- `source`
+- `external_session_id`
+- `transcript_path`
+- `transcript_mtime`
+- `message_count`
+
+每次 pull 时：
+
+1. 如果 session 已绑定 source，则优先按已绑定 `transcript_path` / `external_session_id` 找回原 transcript。
+2. 读取当前 transcript 的全部消息。
+3. 用上次保存的 `message_count` 算增量。
+4. 只 ingest 新增消息，再更新 link 行。
+
+证据：[`scripts/ctx_cmd.py:2124-2195`](file:///tmp/ctx-analysis/scripts/ctx_cmd.py)
+
+这就是 ctx README 里所谓“Exact transcript binding / No transcript drift”的真正落地方式，而不是一句概念宣传。[README:25-30](file:///tmp/ctx-analysis/README.md)
+
+## 1.4 branch 机制如何防止上下文污染
+
+ctx 的 branch 不是软链接，也不是“记一个来源名”。它会直接：
+
+1. 新建 target workstream
+2. 在 `metadata.branch_from` 里记录来源
+3. 把 source workstream 下的 **全部 session 和 entry 快照复制**到 target
+4. 对 attachment 也复制到新的 session/entry 目录
+5. 在 copied session/entry 的 metadata/extras 里标注 `branch_snapshot_from`
+
+证据：[`scripts/ctx_cmd.py:765-900`](file:///tmp/ctx-analysis/scripts/ctx_cmd.py)
+
+更重要的是：**它没有复制 `session_source_link`。**
+
+这意味着 branch 继承的是“保存下来的上下文快照”，不是“未来继续跟着 source transcript 增长的绑定关系”。因此：
+
+- source 后续 pull 不会污染 branch
+- branch 后续 pull 也不会劫持 source 的 transcript
+
+这正是 Orca 目前最需要的分支语义。
+
+## 1.5 搜索索引怎么建立
+
+ctx 用 SQLite FTS5 建 `search_index` 虚表，索引 workstream/session/entry 三类文档，字段包括：
+
+- `kind`
+- `workstream_slug`
+- `workstream_title`
+- `session_title`
+- `body`
+- `tags`
+
+证据：[`contextfun/cli.py:21-35`](file:///tmp/ctx-analysis/contextfun/cli.py)
+
+索引写入策略：
+
+- workstream 改动时重建该 workstream 文档
+- session 改动时重建 session 文档
+- entry 改动时重建 entry 文档
+- 用 `ctx_meta.search_index_version` 控制整库重建
+
+证据：[`contextfun/cli.py:1251-1479`](file:///tmp/ctx-analysis/contextfun/cli.py)
+
+Web 端查询时先走 FTS5，失败再回退 `LIKE` 检索。[`contextfun/web.py:446-586`](file:///tmp/ctx-analysis/contextfun/web.py)
+
+这套机制可直接迁移到 Orca，只要把索引内容换成 Orca 的 dispatch / report / note / transcript delta。
+
+---
+
+## 2. 集成方式
+
+## 2.1 `/ctx` 如何注册到 Claude Code
+
+ctx 不是通过 hooks 注册 slash command，而是通过 **skill 目录安装**：
+
+- `scripts/install_skills.sh` 会把 `skills/claude/*` 软链到 `~/.claude/skills`
+- skill 名就是触发入口，比如 `ctx`、`ctx-resume`、`branch`
+
+证据：[`scripts/install_skills.sh:31-64`](file:///tmp/ctx-analysis/scripts/install_skills.sh)
+
+Claude 主 skill 明确声明：
+
+- `/ctx`
+- `/ctx list`
+- `/ctx search`
+- `/ctx start`
+- `/ctx resume`
+- `/ctx branch`
+
+并把请求转给 `scripts/ctx.sh`。[`skills/claude/ctx/SKILL.md:1-23`](file:///tmp/ctx-analysis/skills/claude/ctx/SKILL.md)
+
+## 2.2 怎么集成到 Codex
+
+Codex 这边 README 讲得很清楚：**Codex 不支持 repo 自定义 slash command，所以用 `ctx` CLI 和 skill alias。**[README:136-138](file:///tmp/ctx-analysis/README.md)
+
+安装方式同样是软链 skill 到 `~/.codex/skills`。[`scripts/install_skills.sh:33-47`](file:///tmp/ctx-analysis/scripts/install_skills.sh)
+
+但 Codex skill 命名更偏命令化：
+
+- `ctx-start`
+- `ctx-resume`
+- `ctx-list`
+- `ctx-branch`
+- `ctx-delete`
+
+这些 skill 最终调用 `ctx` 或 `python3 scripts/ctx_cmd.py ...`。[`skills/codex/ctx-start/SKILL.md:6-26`](file:///tmp/ctx-analysis/skills/codex/ctx-start/SKILL.md), [`skills/codex/ctx-resume/SKILL.md:6-22`](file:///tmp/ctx-analysis/skills/codex/ctx-resume/SKILL.md)
+
+## 2.3 skill 文件结构、hooks 是否使用
+
+我的结论：
+
+- **ctx 核心集成手段是 skill + shell wrapper，不是 hooks。**
+- 仓库里没有看到 Orca 这种 `PreToolUse` / `SessionStart` / `Stop` 级别 hook 体系被用于核心功能。
+- 它有一些外围自动化：
+  - Raycast
+  - Keyboard Maestro
+  - macOS 剪贴板脚本
+
+但这些是 convenience layer，不是架构主干。
+
+换句话说，ctx 的“集成方式”本质是：
+
+> Claude/Codex 负责触发 skill，skill 负责调用 `ctx` CLI，CLI 再去读 SQLite 和本地 transcript。
+
+这和 Orca 的“tmux-bridge + shell + skill”在外形上类似，但运行时职责分层不同。
+
+---
+
+## 3. 架构与依赖
+
+## 3.1 Python 运行时要求、依赖列表
+
+ctx 的代码主体在 Python：
+
+- `contextfun/cli.py`
+- `contextfun/web.py`
+- `scripts/ctx_cmd.py`
+
+Codex skill 文档明确要求 **Python 3.9+**。[`skills/codex/ctx-start/SKILL.md:21-26`](file:///tmp/ctx-analysis/skills/codex/ctx-start/SKILL.md)
+
+我在仓库里没有看到：
+
+- `pyproject.toml`
+- `requirements.txt`
+- 第三方 Python 包声明
+
+代码 import 也基本全是标准库。结论是：
+
+- **运行时依赖是 Python 标准库 + SQLite FTS5 支持**
+- 安装脚本额外依赖：`bash`、`curl`、`tar`、`rsync`、`ln`、`python3`
+
+全局安装脚本证据：[`scripts/install.sh:1-118`](file:///tmp/ctx-analysis/scripts/install.sh)
+
+## 3.2 安装复杂度
+
+安装复杂度不算高，但已经不是“零依赖 shell 脚本”了。
+
+主要路径：
+
+- 本地 clone 后 `./setup.sh`
+- 一行安装 `curl .../install.sh | bash`
+- `npx skills add ... --skill ctx -y -g` 先装 bootstrap skill
+
+证据：README 的安装段落 [32-50, 140-180](file:///tmp/ctx-analysis/README.md)
+
+我的判断：
+
+- 对普通 Claude/Codex 用户，这个复杂度可以接受。
+- 对 Orca 而言，这已经明显超过“shell-only 编排器”的心理模型。
+
+## 3.3 数据存储位置、隐私边界
+
+默认数据位置：
+
+- DB: `~/.contextfun/context.db`
+- 附件: `~/.contextfun/attachments`
+- 当前 workstream 指针: `~/.contextfun/current.json`
+- 也支持 repo-local：`./.contextfun/context.db`
+
+证据：[`contextfun/cli.py:15-20`](file:///tmp/ctx-analysis/contextfun/cli.py), [`scripts/quickstart.sh:49-74`](file:///tmp/ctx-analysis/scripts/quickstart.sh)
+
+隐私边界：
+
+- 不调用 hosted service
+- 不需要 API key
+- 直接读取本机 Claude/Codex transcript 文件
+- Web UI 只允许 loopback host，且 API 要带随机 token
+
+证据：README [23-30](file:///tmp/ctx-analysis/README.md), [`contextfun/web.py:55-78`](file:///tmp/ctx-analysis/contextfun/web.py)
+
+这点对 Orca 是加分项：理念上是 local-first，而不是 SaaS。
+
+---
+
+## 4. 对 Orca 的具体借鉴点
+
+## 4.1 可以直接移植到 Orca 的机制
+
+### A. 绑定表设计
+
+建议 Orca 直接借鉴 `session_source_link` 这一层抽象，至少保存：
+
+- `source`
+- `external_session_id`
+- `source_path`
+- `source_mtime`
+- `message_count`
+- `worktree/workspace`
+
+对 Orca 而言，这里的 `source` 不应只限于 `claude` / `codex`，建议扩成：
+
+- `tmux`
+- `codex`
+- `claude`
+- `manual`
+
+### B. 增量拉取语义
+
+ctx 的 `message_count` 增量拉取是非常实用的最小机制。Orca 可以完全照搬语义：
+
+- 首次绑定时 ingest 全量
+- 后续 pull 时按 message ordinal / line count 只 ingest delta
+
+这能直接解决“worker session 结束后上下文丢失”和“lead 难回溯历史”的核心问题。
+
+### C. 快照分支语义
+
+ctx 的 branch 机制是 Orca 最值得抄的一块：
+
+- 分支复制已保存上下文快照
+- 不共享未来 source 绑定
+- 分支和源 workstream 后续各自演进
+
+Orca 现在的多 worker / 多 worktree 场景，比 ctx 更需要这个隔离语义。
+
+### D. load control
+
+`pin` / `exclude` 这两个语义对 Orca 很实用：
+
+- `pin`: 架构决策、约束、用户拍板内容
+- `exclude`: 大段工具输出、一次性噪声、重复状态播报
+
+这能显著提高 resume 包质量。
+
+### E. workspace-aware candidate selection
+
+ctx 的“优先当前 repo transcript”对 Orca 也成立，只是要把 repo 维度扩成：
+
+- repo
+- worktree
+- pane
+- worker label
+
+## 4.2 可以借鉴但必须改造的点
+
+### A. “current workstream” 指针
+
+ctx 已经支持 `current.<slot>.json`，说明作者意识到多 agent/多槽位问题。[`contextfun/cli.py:173-223`](file:///tmp/ctx-analysis/contextfun/cli.py)
+
+但 Orca 是 tmux 多 pane 模型，建议直接改为：
+
+- `current.<session-name>.<pane-id>.json`
+  或
+- 直接放进 SQLite 的 `agent_slot` 表
+
+不要再依赖单个 current file。
+
+### B. transcript source 抽象
+
+ctx 的 source discovery 强依赖 Claude/Codex 本地 transcript 布局。Orca 如果照搬，会有两个问题：
+
+- tmux pane 自身通信不是 transcript 文件
+- worker 不一定都来自 Claude/Codex
+
+因此 Orca 要把“source adapter”抽象出来：
+
+- adapter 负责 discover current source
+- adapter 负责 extract external id
+- adapter 负责 pull delta
+
+这样未来才能兼容 tmux pane scrollback、message log、Claude transcript、Codex transcript。
+
+### C. Web UI
+
+ctx 的 Web UI 做得不错，但对 Orca 不是第一阶段刚需。
+
+Orca 当前更紧急的是：
+
+1. 可恢复
+2. 可分支
+3. 可搜索
+4. 可追踪 worker 来源
+
+这些先用 CLI + SQLite 就能交付。Web UI 可以放在第二阶段。
+
+## 4.3 不适合 Orca 的部分
+
+### A. 直接依赖 ctx 运行时
+
+不适合，原因很具体：
+
+- ctx 假设单机本地 Claude/Codex transcript 是主数据源
+- ctx 假设 agent 集成入口是 Claude/Codex skills
+- ctx 不理解 tmux pane、lead/worker、bridge message、worktree 调度
+- ctx 的 UI/UX 目标是“恢复一个工作流”，Orca 的目标是“编排多个执行体”
+
+这不是少量 adapter 能抹平的差异。
+
+### B. 直接复用 skill 目录组织
+
+ctx 的 skill 设计偏“面向最终用户的恢复命令”；Orca 的 skill 设计偏“编排协议和角色行为”。两者风格不同，不值得硬对齐。
+
+### C. 把 transcript 发现逻辑写死在核心 CLI
+
+ctx 这么做在它自己的边界里没问题，但 Orca 若照搬，很快就会在多来源场景里失控。Orca 更适合 adapter/plugin 边界。
+
+## 4.4 是否值得让 Orca 直接依赖 ctx
+
+我的明确结论：**不值得。**
+
+更合理的方案是：
+
+- **短期**：参考 ctx 设计，自研一个 Orca-native context store
+- **中期**：如有需要，做一个“导入 ctx workstream / transcript binding”的兼容层
+- **长期**：如果用户确实同时使用 ctx 和 Orca，再考虑单向互操作，而不是运行时耦合
+
+---
+
+## 5. 我建议的 Orca 落地路径
+
+## Phase 1：先做最小可用闭环
+
+新增一个 shell 入口，例如：
+
+- `scripts/orca-context.sh`
+
+新增 SQLite 表：
+
+- `workstream`
+- `session`
+- `entry`
+- `source_link`
+- `meta`
+
+建议默认 DB：
+
+- repo-local: `.orca/context.db`
+
+entry 类型建议直接覆盖 Orca 场景：
+
+- `dispatch`
+- `report`
+- `decision`
+- `todo`
+- `note`
+- `tool_output`
+- `transcript_delta`
+
+首批能力：
+
+1. `orca ctx start <name>`
+2. `orca ctx bind --source tmux|codex|claude`
+3. `orca ctx pull`
+4. `orca ctx resume <name>`
+5. `orca ctx branch <src> <dst>`
+6. `orca ctx search <query>`
+
+## Phase 2：补质量和隔离
+
+- `pin` / `exclude`
+- repo/worktree guard
+- per-pane current slot
+- detached session 语义
+
+## Phase 3：再考虑 UI
+
+- local web 或 TUI
+- lead 视角看多 worker 时间线
+- branch diff / merge assist
+
+---
+
+## 6. 风险与代价
+
+## 6.1 Python 依赖对 Orca “shell-only” 哲学的冲击
+
+这是最大非技术风险。
+
+如果 Orca 引入 ctx 或照着 ctx 上 Python：
+
+- 安装面更大
+- 调试面更大
+- 发布和 bootstrap 更复杂
+- 用户对 Orca 的认知会从“shell orchestrator”变成“本地应用”
+
+我认为这会伤到 Orca 的产品辨识度。
+
+所以我更推荐两种方案中的前者：
+
+- **优先方案**：shell + `sqlite3` CLI 实现核心
+- 备选方案：把 Python 做成可选增强层，而不是核心依赖
+
+## 6.2 项目活跃度、维护风险
+
+按我在 2026-04-22 获取到的信息：
+
+- 最新 commit 在 **2026-04-21**
+- 2026-04-13 到 2026-04-21 之间有连续密集提交
+- GitHub 页面显示约 **68 commits**
+- open issues **1**
+- open PRs **1**
+
+来源：
+
+- 仓库页：<https://github.com/dchu917/ctx>
+- 提交页：<https://github.com/dchu917/ctx/commits/main>
+
+这说明：
+
+- **短期活跃度是高的**
+- 但维护者明显是**单作者主导**
+- 因为项目还很新，长期稳定性和 API 稳定性仍未知
+
+所以维护风险我给的结论是：
+
+- **活跃度风险：低**
+- **Bus factor 风险：中高**
+- **接口稳定性风险：中**
+
+## 6.3 License 兼容性
+
+`ctx` 使用 **MIT License**。[`LICENSE`](file:///tmp/ctx-analysis/LICENSE)
+
+对 Orca 很友好：
+
+- 直接借鉴设计没有问题
+- 参考实现、自研同类机制没有问题
+- 即使未来少量复用代码，MIT 也基本兼容
+
+---
+
+## 7. 最终建议
+
+## 推荐
+
+- 借鉴 ctx 的以下设计：
+  - `workstream/session/entry` 三层模型
+  - `source_link` 绑定表
+  - `message_count` 增量拉取
+  - 快照分支而非共享未来绑定
+  - `pin/exclude` 负载控制
+  - workspace-aware transcript 选择
+
+## 不推荐
+
+- 不要让 Orca 直接依赖 ctx 作为上下文系统核心。
+- 不要把 Claude/Codex transcript 路径假设写死到 Orca 核心里。
+- 不要在第一阶段就做 Web UI。
+
+## 需讨论
+
+1. Orca 是否接受 Python 作为可选扩展层。
+2. Orca 的 source adapter 第一批要不要把 `tmux` 作为头号来源。
+3. resume pack 是否要像 ctx 一样默认“load-only until user acts”。
+
+## 一句话判断
+
+**ctx 值得学，甚至很值得学；但适合 Orca 的方式是“借模型、自研实现”，不是“直接接入 ctx”。**

--- a/docs/research/competitor-analysis/omc-deep-dive.md
+++ b/docs/research/competitor-analysis/omc-deep-dive.md
@@ -1,0 +1,197 @@
+# OMC 深度分析（oh-my-claudecode）
+
+> 仓库：[Yeachan-Heo/oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode)
+> 状态：🟢 已补充源码/文档实测细节（少数运行时行为仍未二进制级验证）
+
+## 1. 定位
+
+Claude Code 的多 agent 编排 plugin，"Don't learn Claude Code. Just use OMC."
+
+- 当前主 catalog 为 19 个 unified agents（另有兼容 alias）+ 36 skills
+- 零配置，自动检测最佳模式和 agent
+- 声称 "ship features 3-5× faster, save 30-50% tokens"
+
+## 2. 安装 / 入口
+
+### 2.1 Plugin 路径（推荐）
+
+在 Claude Code 会话里：
+```
+/plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
+/plugin install oh-my-claudecode
+```
+
+### 2.2 npm 路径
+
+```
+npm i -g oh-my-claude-sisyphus@latest
+```
+
+### 2.3 首次使用
+
+```
+/setup                      # 首次配置（cc 内）
+/autopilot "build a REST API"  # 自然语言开工
+autopilot: build a REST API     # 等价的自然语言形式
+```
+
+## 3. Team 命令（多 worker）
+
+```
+omc team 1:claude "implement payment flow"
+omc team 2:codex "review auth module"
+omc team 2:gemini "redesign UI accessibility"
+```
+
+或在 cc 内：
+```
+/team
+```
+
+## 4. 实测补充
+
+- [x] **完整 32 specialists 清单**
+  - 结论：**当前公开运行时不是 32 specialists，而是 19 个 unified agents。**
+  - 证据链：
+    - README 写的是 `19 specialized agents`。`/tmp/omc-research/README.md:250`
+    - 官网 changelog 写的是 v4.3.x 收敛成 `19 unified agents`。来源：`https://yeachan-heo.github.io/oh-my-claudecode-website/docs.html`
+    - 运行时 registry 在 `getAgentDefinitions()`，主 agent 共 19 个。`/tmp/omc-research/src/agents/definitions.ts:212-250`
+    - 仓库里仍有旧注释说 `32 specialized AI agent definitions`，但那是过期内部文档。`/tmp/omc-research/src/AGENTS.md`
+  - 当前主 catalog 与能力边界：
+    - `explore`：内部 codebase 搜索/结构理解；外部资料不归它。`src/agents/explore.ts:39-40`
+    - `analyst`：需求澄清、隐含约束、风险识别。`src/agents/analyst.ts:38`
+    - `planner`：创建工作计划，明确 NEVER implements。`src/agents/planner.ts:37`
+    - `architect`：高难调试与架构设计，read-only consultation。`src/agents/architect.ts:43`
+    - `debugger`：根因分析、回归定位、编译/构建错误。`src/agents/definitions.ts:55-60`
+    - `executor`：直接实现；明确 NEVER delegate/spawn。`src/agents/executor.ts:38`
+    - `verifier`：完成证据、claim 校验、测试充分性。`src/agents/definitions.ts:66-71`
+    - `tracer`：因果追踪、竞争性假设、下一步 probe。`src/agents/tracer.ts:38`
+    - `security-reviewer`：安全审计、OWASP、边界与漏洞检测。`src/agents/definitions.ts:101-106`
+    - `code-reviewer`：全面代码审查、质量/兼容性/逻辑缺陷。`src/agents/definitions.ts:112-117`
+    - `test-engineer`：测试策略、覆盖率、flaky hardening。`src/agents/definitions.ts:86-91`
+    - `designer`：纯视觉/UI/UX 变更；纯逻辑前端改动不建议走它。`src/agents/designer.ts:42`
+    - `writer`：README / API docs / 架构文档 / 用户指南。`src/agents/writer.ts:38`
+    - `qa-tester`：交互式 CLI / 服务验证，依赖 tmux。`src/agents/qa-tester.ts:43`
+    - `scientist`：数据分析、统计、Python EDA。`src/agents/scientist.ts:51`
+    - `git-master`：atomic commit / rebase / history management。`src/agents/definitions.ts:124-129`
+    - `document-specialist`：外部文档、SDK/API/reference lookup。`agents/document-specialist.md:2-3`
+    - `code-simplifier`：代码简化、可维护性提升。`src/agents/definitions.ts:135-140`
+    - `critic`：计划/方案/分析评审，补 “What's Missing”。`src/agents/critic.ts:37`
+  - 额外说明：`docs/REFERENCE.md` 仍写 `Agents (29 Total)`，更像“主 agent + 兼容 alias/旧名”的总盘子，不等于当前主 catalog 数。`/tmp/omc-research/docs/REFERENCE.md:14`
+
+- [x] **/setup 实际做什么**
+  - `/setup` 与 `/omc-setup` 都是 setup 入口。`/tmp/omc-research/README.md:75-82`, `107-109`
+  - setup 主要落盘到：
+    - `~/.claude/agents/`
+    - `~/.claude/skills/`
+    - `~/.claude/hooks/`
+    - `~/.claude/hud/`
+    - `~/.claude/settings.json`
+    - `~/.claude/CLAUDE.md`
+    - `~/.claude/.omc-version.json`
+    - `~/.claude/.omc-config.json`
+    - 路径常量定义：`/tmp/omc-research/src/installer/index.ts:31-38`
+  - 关键动作：
+    - 写 agent files。`src/installer/index.ts:1671-1683`
+    - 同步 bundled skills。`src/installer/index.ts:1751-1761`
+    - 合并/备份 `CLAUDE.md`。`src/installer/index.ts:1779-1810`
+    - 生成 `hud/omc-hud.mjs`。`src/installer/index.ts:1813-1843`
+    - 更新 `settings.json` 的 hooks/statusLine。`src/installer/index.ts:1849-1911`
+    - 保存 `.omc-version.json`。`src/installer/index.ts:1917-1925`
+    - 保存 `.omc-config.json` 中的 node 路径。`src/installer/index.ts:1875-1889`
+  - hook 注册位置：
+    - `~/.claude/settings.json` 里合并 hooks 配置。`src/installer/index.ts:450-495`, `1849-1911`
+    - standalone hook 脚本落到 `~/.claude/hooks/*.mjs`。`src/installer/index.ts:588-639`
+
+- [x] **`/team` 与 `omc team` 的差异**
+  - 这不是别名，而是两个不同 runtime。
+  - `/team`
+    - Claude Code 会话内 native team workflow。`/tmp/omc-research/README.md:123-147`
+    - staged pipeline：`team-plan → team-prd → team-exec → team-verify → team-fix`。`README.md:133-145`
+    - 需要 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`。`README.md:137-145`
+  - `omc team`
+    - shell/terminal 里的 CLI runtime，起 tmux CLI workers。`README.md:149-176`
+    - 支持 `status` / `shutdown` / `api`。`/tmp/omc-research/docs/REFERENCE.md:353-367`
+  - 选择建议：
+    - Claude 内同质 Team 协作：`/team`
+    - 真实 Codex/Gemini/Claude CLI panes：`omc team`
+
+- [x] **Hook 机制**
+  - 覆盖事件：
+    - `UserPromptSubmit`
+    - `SessionStart`
+    - `PreToolUse`
+    - `PermissionRequest`
+    - `PostToolUse`
+    - `PostToolUseFailure`
+    - `SubagentStart`
+    - `SubagentStop`
+    - `PreCompact`
+    - `Stop`
+    - `SessionEnd`
+  - 汇总表：`/tmp/omc-research/docs/REFERENCE.md:620-636`
+  - 关键语义：
+    - `autopilot` / `ralph` / `ultrawork` 是 skills，不是 hooks。
+    - 真正阻止早停的是 `persistent-mode` Stop hook。`/tmp/omc-research/docs/HOOKS.md:230-237`
+
+- [x] **按需 spawn 实现**
+  - 外层先起 **detached Node runtime process**。`/tmp/omc-research/src/cli/team.ts:331-370`
+  - runtime 再创建/管理 tmux panes。`/tmp/omc-research/src/team/runtime-v2.ts:1-14`
+  - pane 内 worker 通过 `spawnWorkerInPane()` 注入启动命令。`/tmp/omc-research/src/team/tmux-session.ts:250-339`
+  - 所以准确说法是：
+    - control plane = detached Node runtime
+    - worker execution = tmux pane + CLI process
+
+- [x] **跨 agent delegate**
+  - `omc team N:codex|gemini|claude` 用 provider contract 选 CLI binary。`/tmp/omc-research/src/team/model-contract.ts:160-245`
+  - Codex worker 用的是真实 `codex` CLI，带 `--dangerously-bypass-approvals-and-sandbox`，并支持 prompt mode。`src/team/model-contract.ts:181-210`
+  - 启动方式是 tmux pane 内执行 shell + binary，不是一次性 `--no-interactive` 子进程。`/tmp/omc-research/src/team/tmux-session.ts:269-311`
+
+- [x] **`/team status` 是否存在**
+  - shell 侧 `omc team status <team-name>` 已确认存在。`/tmp/omc-research/src/cli/commands/team.ts:26-45`, `683-732`, `855-860`
+  - in-session `/team status` 本轮未直接验证，只能确认 Team API/Task API 存在。来源：`https://yeachan-heo.github.io/oh-my-claudecode-website/docs.html`
+
+- [x] **License**
+  - MIT。`/tmp/omc-research/LICENSE`
+
+- [x] **Issue #716 进展**
+  - Issue 页面状态是 **Closed**，但无关联 PR/branch/milestone。来源：`https://github.com/Yeachan-Heo/oh-my-claudecode/issues/716`
+  - 提案内容是让 `omc` 默认像 OMX 一样把 Claude 包进 tmux session，并支持 `--no-tmux`。同页 issue body 可见。
+  - 官网 CLI 文档已经出现 `Just run omc. It launches Claude Code inside a tmux session automatically.` 的口径，但本轮未完整追到主 launcher 源码实现，所以只能写成：
+    - **Issue 已关闭**
+    - **文档口径显示该方向已采纳**
+    - **源码侧未完全验证到最终落地路径**
+
+- [x] **失败/中断恢复**
+  - runtime snapshot 会跟踪 `deadWorkers` / `nonReportingWorkers`。`/tmp/omc-research/src/team/runtime-v2.ts:108-143`, `1388-1544`
+  - `all workers dead && outstanding work` 时 runtime-cli 直接 fail fast。`/tmp/omc-research/src/team/runtime-cli.ts:502-505`
+  - 另有 worker auto-restart 模块，带 sidecar JSON + exponential backoff + `maxRestarts=3`。`/tmp/omc-research/src/team/worker-restart.ts:1-120`
+  - 但 CLI workers 不写 `shutdown-ack.json`，更多依赖 tmux kill 和运行时检测。`/tmp/omc-research/src/team/runtime.ts:922-948`
+
+- [x] **Token 节省 30-50% 的来源**
+  - README 归因到 `Smart model routing` / `Cost optimization`。`/tmp/omc-research/README.md` “Why oh-my-claudecode?” 段
+  - 本轮没有找到公开 benchmark methodology 或可复现实验。
+  - 因此只能写：
+    - **作者声称主要来源是 model routing**
+    - **未验证到独立实验数据**
+
+## 5. 对 Orca 的启示
+
+| OMC 特性 | Orca 应该学吗 | 怎么学 |
+|---|---|---|
+| Plugin 形式安装 | **学** | 把 `install.sh` 退化为可选，主入口做成 cc plugin |
+| `/autopilot` 入口 | **学** | 抄 `/orca dispatch "..."` |
+| 按需 spawn worker | **学** | `start.sh` 默认单 pane，worker 显式调用才建 |
+| 19 unified agents | **不学** | Orca 差异化在异构 agent，不在 specialist 库 |
+| 自动选最佳 agent | **可选学** | Phase 2 可考虑 lead 自动选 worker 类型 |
+| 零配置 | **学** | 砍掉 install.sh 的多步骤副作用 |
+
+## 6. 参考材料
+
+- [仓库主页](https://github.com/Yeachan-Heo/oh-my-claudecode)
+- [官网](https://yeachan-heo.github.io/oh-my-claudecode-website/)
+- [REFERENCE.md](https://github.com/Yeachan-Heo/oh-my-claudecode/blob/main/docs/REFERENCE.md)
+- [Issue #716 - tmux 默认行为](https://github.com/Yeachan-Heo/oh-my-claudecode/issues/716)
+- [agentskills.so 的 omc-setup](https://agentskills.so/skills/yeachan-heo-oh-my-claudecode-omc-setup)
+- [npm: oh-my-claude-sisyphus](https://www.npmjs.com/package/oh-my-claude-sisyphus)
+- 第三方介绍：[OpenClaw API blog](https://openclawapi.org/en/blog/2026-03-31-oh-my-claudecode-32-agents)、[emelia.io](https://emelia.io/hub/oh-my-claudecode-multi-agent)

--- a/docs/research/competitor-analysis/omx-deep-dive.md
+++ b/docs/research/competitor-analysis/omx-deep-dive.md
@@ -1,0 +1,267 @@
+# OMX 深度分析（oh-my-codex）
+
+> 仓库：[staticpayload/oh-my-codex](https://github.com/staticpayload/oh-my-codex)
+> 备用名：scalarian/oh-my-codex
+> 状态：🟢 已补充源码/文档实测细节（少数运行时行为仍未二进制级验证）
+
+## 1. 定位
+
+OpenAI Codex CLI 的编排层，"like oh-my-zsh but for Codex"。
+
+特点：
+- 多 agent team（执行/审查等角色）
+- 持久 memory + state
+- git worktree 集成
+- 结构化 workflow（autopilot / TDD / code review / planning）
+- README/About 仍提 Async Claude Code delegation，但 v2 源码与 FAQ 明确说明已不再是 Claude bridge
+
+## 2. 安装 / 入口
+
+### 2.1 安装
+
+把 GitHub repo URL 粘贴给你的 agent，触发自动依赖安装、构建、CLI 链接。
+
+或：标准 npm install（需 worker 确认包名）。
+
+### 2.2 首次配置
+
+```
+omx setup       # 项目初始化
+omx doctor      # 环境自检
+omx hud         # 仪表盘验证
+```
+
+### 2.3 主入口
+
+```
+$ultrawork "ship the feature end to end"
+```
+
+也支持：
+```
+$tdd "write tests for auth"
+$plan "design the migration"
+```
+
+## 3. Team / Worker 模型
+
+```
+omx team spawn executor          # 显式起 worker
+omx team queue [task]            # 任务入队
+omx team inbox                   # 看队列状态
+```
+
+worker 自取任务（claim 模型），不是 lead 直接 push。
+
+## 4. 其他子命令
+
+```
+omx session                  # 持久工作上下文
+omx explore index            # codebase 索引
+omx hooks status             # hook 检查
+omx plugins doctor           # 插件检查
+```
+
+## 5. 实测补充
+
+- [x] **完整 CLI 命令列表**
+  - `omx --help` 对应源码常量：
+    - `omx setup`
+    - `omx doctor`
+    - `omx hud`
+    - `omx team`
+    - `omx explore`
+    - `omx session`
+    - `omx autoresearch`
+    - `omx agents`
+    - `omx plugins`
+    - `omx hooks`
+    - `omx version`
+  - 证据：`/tmp/omx-research/packages/cli/src/help.ts:1-20`
+  - `omx team` 子命令：
+    - `init|status|spawn|queue|claim|heartbeat|complete|review|message|await|inbox|logs|resume|shutdown`
+    - 证据：`/tmp/omx-research/packages/cli/src/commands/team.ts:19-167`
+
+- [x] **`omx hud` 仪表盘真实样子**
+  - 当前 HUD 是纯文本，不是 curses/TUI。
+  - 固定输出字段：
+    - `Branch`
+    - `Session`
+    - `Tasks`
+    - `Modes`
+    - `Team`
+    - `Inbox`
+    - `Priority note`
+    - `Memory`
+    - `Autoresearch`
+  - 证据：`/tmp/omx-research/packages/core/src/hud.ts:68-93`
+  - 未实机执行时，可按源码推得样式：
+    ```text
+    OMX HUD
+    =======
+    Branch: main
+    Session: session_xxx (active)
+    Tasks: 3 queued, 1 active, 0 in review
+    Modes: ultrawork, plan
+    Team: omx-team (1/3 busy, 0 stale, backend tmux)
+    Inbox: 2 open, Reviews: 1 pending
+    Priority note: none
+    Memory: empty
+    Autoresearch: idle
+    ```
+
+- [x] **队列模型实现**
+  - `team.json` 里直接有 `taskQueue: string[]`。`/tmp/omx-research/packages/core/src/team.ts:37-53`
+  - `queueTeamTask()` 把 taskId 放进 `taskQueue` 并把任务状态改为 `queued`。`packages/core/src/team.ts:253-260`
+  - `claimTeamTask()`：
+    - worker 置 `busy`
+    - 写 `leaseExpiresAt`
+    - 从 `taskQueue` 移除
+    - task 状态变 `in_progress`
+    - 证据：`packages/core/src/team.ts:262-289`
+  - 结论：
+    - **不是 socket**
+    - **不是文件锁**
+    - **是 repo-local JSON 队列 + lease 字段**
+
+- [x] **持久 state 存储位置**
+  - 产品真相是 repo 下的 `.omx/`。`/tmp/omx-research/docs/ARCHITECTURE.md:53-78`
+  - 目录契约：
+    - `.omx/state`
+    - `.omx/sessions`
+    - `.omx/plans`
+    - `.omx/research`
+    - `.omx/team`
+    - `.omx/logs`
+    - `.omx/memory`
+    - `.omx/hud-config.json`
+  - 证据：`/tmp/omx-research/packages/core/src/contract.ts:5-112`
+  - 关键文件：
+    - `state/tasks.json`
+    - `state/reviews.json`
+    - `state/inbox.json`
+    - `state/hooks.json`
+    - `team/team.json`
+    - `logs/ledger.json`
+  - 结论：
+    - **不是 SQLite**
+    - **是 repo-local JSON 文件族**
+
+- [x] **memory 机制**
+  - `memory/<namespace>.json`，默认 namespace=`project`。`/tmp/omx-research/packages/core/src/memory.ts:21-48`
+  - 结构：
+    - `namespace`
+    - `summary`
+    - `facts[]`
+    - `updatedAt`
+  - 保留的是项目摘要和事实，不是 transcript 回放。
+
+- [x] **Async Claude Code delegation 怎么实现**
+  - 结论：**当前 v2 没有实现。**
+  - 证据链：
+    - README/About 仍保留“Async Claude Code delegation (no timeouts)”的旧文案。
+    - FAQ 明确写：`Is this still a Claude bridge? No.` `docs/FAQ.md:3-5`
+    - Architecture 写：`durable orchestration primitives instead of a Claude bridge`。`docs/ARCHITECTURE.md:29-35`
+    - README 也写：`There is no Claude bridge in this release.` `/tmp/omx-research/README.md`
+  - 所以这是**文案滞后**，不应当算当前能力。
+
+- [x] **TDD/plan workflow 完整流程**
+  - `$tdd`
+    - 红-绿-重构三段式
+    - 明确 `No production code without a failing test first`
+    - 输出要包含 behavior / failing signal / minimal implementation / final verification command
+    - 证据：`/tmp/omx-research/skills/tdd/SKILL.md`
+  - `$plan`
+    - 先读 `.omx/plans/*-requirements.md`、`brownfield-map.md`、`.omx/research/summary.md`
+    - 每个 slice 写清 files / verify / done / deps
+    - 交付物是 `<phase>.md` 和 `<phase>-verification.md`
+    - 证据：`/tmp/omx-research/skills/plan/SKILL.md`
+  - `$ultrawork`
+    - 默认路径是 interview -> plan -> execute -> verify
+    - 模糊需求走 `$deep-interview`，并行耐久工作走 `$team`
+    - 证据：`/tmp/omx-research/skills/ultrawork/SKILL.md`
+
+- [x] **git worktree 集成**
+  - 本轮没有验证到 team runtime 默认自动创建 worker worktree。
+  - 当前核心实现聚焦于 tmux session/window + `.omx/` durable state。`/tmp/omx-research/packages/core/src/team.ts:137-250`
+  - 所以最保守的写法应是：
+    - **未验证到自动创建**
+    - **骨架中“git worktree 集成”更像能力方向，不是默认命令流的显式行为**
+
+- [x] **hook 机制**
+  - 事件集：
+    - `SessionStart`
+    - `PreToolUse`
+    - `PostToolUse`
+    - `UserPromptSubmit`
+    - `Stop`
+    - 证据：`/tmp/omx-research/packages/core/src/hooks.ts:7-21`
+  - 预设：
+    - `workspace-context`
+    - `memory`
+    - `safety`
+    - `review`
+    - `telemetry`
+    - 证据：`packages/core/src/hooks.ts:41-123`, `docs/HOOKS.md:5-11`
+  - 安装位置：
+    - repo-local：`<repo>/.codex/hooks.json`
+    - handlers：`<repo>/.codex/hooks/omx/*.mjs`
+    - personal 也支持 `~/.codex/hooks.json`
+    - 证据：`packages/core/src/hooks.ts:138-215`, `docs/HOOKS.md:13-25`
+  - 限制：
+    - Codex hooks 仍是 experimental
+    - `PreToolUse` / `PostToolUse` 主要面向 Bash
+    - Windows 不在支持范围
+    - 证据：`docs/HOOKS.md:34-38`
+
+- [x] **License**
+  - MIT。`/tmp/omx-research/LICENSE`
+
+- [x] **维护活跃度**
+  - 当前可见提交集中在两个时间点：
+    - 2026-02-08 初始发布
+    - 2026-04-01 一波 v2 product 化冲刺
+  - 本地 `git log` 已拿到：
+    - `2026-04-01` 多次 merge/feat/fix
+    - `2026-02-08` initial release
+  - 结论：
+    - **不是持续高频日更**
+    - **而是阶段性集中提交**
+
+- [x] **失败恢复**
+  - worker 有 `leaseExpiresAt`；超时后 `reconcileWorker()` 会把 `busy` worker 标成 `stale`。`/tmp/omx-research/packages/core/src/team.ts:127-134`
+  - 但任务一旦被 claim，会从 `taskQueue` 中移除。`packages/core/src/team.ts:262-289`
+  - 这意味着 worker 死亡后：
+    - **不会自动重新入队**
+    - 需要 operator 手动 `status` / `claim` / `queue` / `spawn` 修复
+
+## 6. 对 Orca 的启示
+
+| OMX 特性 | Orca 应该学吗 | 怎么学 |
+|---|---|---|
+| `$ultrawork` skill 入口 | **学** | 与 OMC 的 `/autopilot` 一致，做 `/orca dispatch` |
+| 三步 onboarding（install/setup/doctor） | **可选学** | 加 `orca doctor` 自检命令 |
+| **任务队列模型** | **重点学** | Phase 2 引入队列，避免 lead 直接硬指派；worker claim 模型 |
+| **`omx hud` 仪表盘** | **学** | Orca 缺乏全局观测，可加 `orca hud` |
+| persistent state | **学** | 与 ctx 借鉴方向重合，自研 sqlite 实现 |
+| TDD/plan/review workflow | **可选学** | Orca 哲学是"弱研发流程"，但可作为可选 skill |
+| Async delegation 文案 | **不直接学** | 当前 README 文案与 v2 实现不一致，先学 durable queue/event，再避免写超前营销文案 |
+
+## 7. OMX vs OMC 关键差异
+
+| 维度 | OMC | OMX |
+|---|---|---|
+| 宿主 | Claude Code | Codex CLI |
+| 入口 | `/autopilot` | `$ultrawork` |
+| 任务分发 | 智能路由（自动选 specialist） | 队列 + claim |
+| 自动化程度 | 极高 | 中（保留用户控制） |
+| 多 agent 架构 | 19 unified agents + 兼容 alias | architect / executor / reviewer 等少数固定角色 |
+| tmux 关系 | 可选（Issue #716 已 Closed，文档口径采纳默认 tmux 包装） | tmux-aware（worker spawn 用） |
+
+**对 Orca 的启示**：OMC 是"自动化优先"，OMX 是"显式控制优先"。Orca 应该走 OMX 路线，因为 Orca 的差异化是"弱研发流程 + 异构 agent 编排"，需要保留人工编排的控制点。
+
+## 8. 参考材料
+
+- [GitHub: staticpayload/oh-my-codex](https://github.com/staticpayload/oh-my-codex)
+- [Verdent Guides: What Is OMX](https://www.verdent.ai/guides/what-is-oh-my-codex-omx)
+- [FindSkill.ai: oh-my-codex explained](https://findskill.ai/blog/oh-my-codex-explained/)

--- a/docs/research/competitor-analysis/orca-evolution-proposal.md
+++ b/docs/research/competitor-analysis/orca-evolution-proposal.md
@@ -1,0 +1,186 @@
+# Orca 演进方向建议
+
+> 基于：[comparison-matrix.md](./comparison-matrix.md) + [ux-issues.md](./ux-issues.md) + [ctx-deep-dive.md](./ctx-deep-dive.md)
+> 时间：2026-04-22
+
+## 1. 三个独立但相关的议题
+
+| 议题 | 来源 | 严重性 | 优先级 |
+|---|---|---|---|
+| **A. 入口范式重构** | Nick 反馈 + OMC/OMX 对照 | P0（用户 churn） | 立即 |
+| **B. 通信连续性** | Nick 反馈 + OMX 队列模型 | P1（影响日常顺畅） | A 后 |
+| **C. 上下文持续性** | ctx 借鉴 | P2（增量价值，非阻塞） | A、B 后 |
+
+## 2. 议题 A：入口范式重构（P0）
+
+### 2.1 现状
+
+- 入口在 shell 外（`orca` 命令）
+- 启动即创建 tmux session + 多 pane
+- 用户必须懂 tmux/worktree/bridge 才能用
+- "我突然就不想用了"
+
+### 2.2 目标
+
+让 Orca 同时支持两种用法：
+
+**模式 A（OMC 风格，新默认）**：
+- 用户开 cc/codex
+- 在 Agent 内 `/orca dispatch "任务"`
+- Orca 在后台按需创建 worker（默认还是当前 shell，需要并发才 spawn 新 pane）
+- 用户全程在原 Agent 会话内，看不到 tmux
+
+**模式 B（当前行为，保留为高级用法）**：
+- 用户在 shell 跑 `orca`
+- 创建多 pane 布局
+- lead/worker 显式分离
+
+### 2.3 改造范围（粗）
+
+| 文件 | 改造内容 |
+|---|---|
+| `start.sh` | 加 `--no-tmux` / `--single-pane` 默认模式；旧行为通过 `--legacy` 或显式参数保留 |
+| `install.sh` | hook 全量注册（参考 OMC 11 个事件、OMX 5 个事件的覆盖面）但默认 dormant 不主动 push；`/orca` 调用才激活通信流 |
+| `skills/orca/SKILL.md` | 新增 `dispatch` 入口（cc/codex 内调用）；区分"在 Agent 内"和"在 shell 外"两种调用上下文 |
+| 新增 `bin/orca-dispatch` | 给 Agent skill 调用的 shell 入口，封装 tmux 按需创建逻辑 |
+| `tmux-bridge` | 加嵌套检测（已在 tmux 内时不再创建新 session） |
+
+### 2.4 验收
+
+- [ ] 在 cc 里 `/orca dispatch "..."` 能开工，不见 tmux
+- [ ] 任务完成 worker 自动清理，不留僵尸 pane
+- [ ] 老用户的 `orca` 命令仍能创建多 pane
+- [ ] 嵌套场景（tmux 内启 cc）不再触发二次 tmux 创建
+
+## 3. 议题 B：通信连续性（P1）
+
+### 3.1 现状
+
+- lead 用 `tmux-bridge read $WORKER 5` 同步等
+- PreToolUse hook 给 idle 通知，但不能告知"结果就绪"
+- 用户跳进 worker pane 直接打字纠偏（延迟太高）
+
+### 3.2 目标
+
+事件驱动的 lead/worker 通信。
+
+### 3.3 改造范围（粗）
+
+| 文件 | 改造内容 |
+|---|---|
+| `tmux-bridge` | 加 `wait-event` 模式：worker 完成时主动 signal lead |
+| `skills/orca/SKILL.md` | read 周期从 5s → 事件驱动 |
+| 新增 `orca worker status` | lead 不用 read pane 也能查 worker 状态（基于 SQLite 或 fifo） |
+| 借鉴 OMX 队列模型 | 引入 `orca task queue` / `orca task claim`，worker 自取任务 |
+
+### 3.4 验收
+
+- [ ] worker 完成任务 lead 1s 内得知
+- [ ] lead 可以同时跟踪 N 个 worker 而不阻塞
+- [ ] 用户介入 worker 不再需要跳 pane
+
+## 4. 议题 C：上下文持续性（P2）
+
+### 4.1 现状
+
+- pane scrollback 即丢
+- worker session 死后无法续
+- lead 难以回溯历史决策
+
+### 4.2 目标
+
+借鉴 ctx 的 workstream 模型，自研轻量上下文存储。
+
+### 4.3 改造范围（粗）
+
+详见 [ctx-deep-dive.md 第 5 节](./ctx-deep-dive.md)，摘要：
+
+**Phase 1**：CLI + SQLite 最小闭环
+- 新增 `scripts/orca-context.sh`
+- 新增 SQLite 表：`workstream/session/entry/source_link/meta`
+- 默认 DB：`.orca/context.db`
+- 首批命令：`orca ctx start/bind/pull/resume/branch/search`
+
+**Phase 2**：质量与隔离
+- `pin` / `exclude` load control
+- repo/worktree guard
+- per-pane current slot
+
+**Phase 3**：UI（如有需要）
+- TUI 或 local web
+
+### 4.4 验收
+
+- [ ] worker pane 死后能从 DB 恢复对话上下文
+- [ ] lead 可以 `orca ctx search "..."` 查跨 session 决策
+- [ ] worktree 间分支不污染（快照分支）
+
+## 5. 总体路线图
+
+```
+P0 (1-2 周): 入口范式重构
+   ├─ start.sh --no-tmux 默认
+   ├─ /orca dispatch skill
+   ├─ install.sh hook dormant
+   └─ 嵌套检测
+
+P1 (2-4 周): 通信连续性
+   ├─ tmux-bridge wait-event
+   ├─ orca worker status
+   └─ orca task queue (借鉴 OMX)
+
+P2 (4-8 周): 上下文持续性
+   ├─ orca-context.sh + sqlite schema
+   ├─ orca ctx start/bind/pull
+   ├─ orca ctx resume/branch/search
+   └─ pin/exclude
+```
+
+## 6. 不做的事
+
+- ❌ 不做 OMC 的 19 unified agents 库（差异化在异构 agent，不在 specialist 数量）
+- ❌ 不引入 Python 作为核心依赖（保持 shell-only 哲学）
+- ❌ 不做强结构化 workflow（Orca 是"弱研发流程"，OMX 那套不适合）
+- ❌ 不做 Web UI（Phase 3 再说，且优先 TUI）
+- ❌ 不直接依赖 ctx 运行时（产品边界不同）
+
+## 7. 风险与开放问题
+
+### 风险
+
+| 风险 | 缓解 |
+|---|---|
+| 入口范式改变破坏老用户 | `--legacy` 参数 + 文档明确兼容性 |
+| Hook dormant 后部分功能默认不可见 | `/orca status` 命令显式查询 |
+| 队列模型增加复杂度 | Phase 2 才引入，不影响 P0 |
+| SQLite 引入数据迁移成本 | Phase 3 再说，且向前兼容 |
+
+### 开放问题（待你拍板）
+
+1. **入口范式重构是另起新分支还是增量改？**
+   - 我倾向新分支并行做，避免破坏当前用户
+   - 拍板后再细分任务
+
+2. **`/orca dispatch` 暴露给 cc 还是 codex 优先？**
+   - 我倾向先 cc（用户基数大）
+   - codex 同步跟进
+
+3. **`orca task queue` 是 P1 还是 P2？**
+   - 我倾向 P1，因为它解决"通信连续性"的根本
+   - 但实现成本不低（需要持久化）
+
+4. **上下文存储是 sqlite 还是 jsonl？**
+   - 倾向 sqlite（搜索、join、原子性）
+   - jsonl 更"shell 友好"，但搜索能力差
+
+5. **是否要做 `orca doctor`？**
+   - 借鉴 OMX 的 doctor 命令，提升首次安装可靠性
+   - 成本低，建议加入 P0
+
+## 8. 下一步
+
+如果方向认可，建议：
+
+1. 让 worker 把 OMC/OMX 的实测细节补完（[omc-deep-dive.md 第 4 节](./omc-deep-dive.md)、[omx-deep-dive.md 第 5 节](./omx-deep-dive.md)）
+2. 起一个新 worktree 做 P0（`orca-entry-refactor`）
+3. P0 期间不做 P1/P2，避免范围蔓延

--- a/docs/research/competitor-analysis/ux-issues.md
+++ b/docs/research/competitor-analysis/ux-issues.md
@@ -1,0 +1,176 @@
+# Orca UX 问题清单 —— Nick 反馈拆解
+
+> 来源：2026-04-21 与 Nick 的微信对话
+> 整理时间：2026-04-22
+
+## 摘要
+
+Nick 是 Orca 的早期用户。他在 2026-04-21 给出了一组连续反馈，最终情绪曲线：
+"想试试" → "感觉不好上手" → "突然就不想用了" → "打破幻想了"。
+
+**这是 Orca 当前最严重的产品级 churn 信号**。本文档拆解他的具体反馈，对应到 Orca 的设计问题。
+
+---
+
+## 1. 反馈原文 → 设计问题映射
+
+### 痛点 1：入口反了
+
+> Nick: "感觉不是很好上手，不知道第一步该怎么用"
+> Nick: "当我启动 Claude Code 的时候，orca 不会自动 hooks 上吗？还需要我手动执行下 orca?"
+
+**用户期望**：先打开 Agent → Agent 里调用 orca
+
+**Orca 当前**：先 `orca` 命令 → 创建 tmux session → 把 cc/codex 装进 pane
+
+**关键证据**：OMC/OMX 都是后者范式，Nick 明确说"使用姿势我倾向于类似 OMC OMX"。
+
+**对应文件**：
+- `start.sh`（创建 tmux session 的入口）
+- `install.sh`（安装 hook、skill）
+- `skills/orca/SKILL.md`（lead/worker 协议）
+
+---
+
+### 痛点 2：强制 tmux 入侵
+
+> Nick: "但这个入侵就有点严重了吧，能不能实现另说，如果我就是单纯只想启动 cc, 不想装在 tmux 里呢，然后还要解决 tmux 内启动 cc, hook 在再次触发 orca 的嵌套问题"
+
+**用户诉求**：tmux 应该是"任务需要并发时才出现"的能力，不是入口前提
+
+**Orca 当前**：tmux 是必须的，不开 tmux 就用不了 orca
+
+**衍生问题**：嵌套触发——用户在 tmux 里启动 cc，cc 的 hook 又触发 orca 创建新 tmux，套娃
+
+**对应文件**：
+- `start.sh`（无条件创建 tmux）
+- 任何 `SessionStart` hook 注册的入口
+
+---
+
+### 痛点 3：默认多 pane 太重
+
+> 我（赛赛）："启动 orca app，然后它会自动拉起 1 个 claude 和 2 个 codex?"
+> Nick: "nonono，这个太丑了"
+> Nick: "我突然就不想用了"
+> Nick: "打破幻想了"
+
+**用户诉求**：默认应只有 1 个 pane，开几个 pane 由任务并发决定
+
+> Nick: "默认肯定只能有一个，然后开多少个 tmux pane 得根据任务的并发量去评估"
+
+**Orca 当前**：`start.sh` 起手就建好 lead + N worker pane
+
+**对应文件**：
+- `start.sh:??`（pane 创建逻辑，需 worker 确认行号）
+
+---
+
+### 痛点 4：hook 介入要"按需生效"
+
+> Nick: "我觉得是要 hooks 上，但是否生效取决于我是否要让它干过"
+> 我："是否要让他干活，可以参考下 OMX OMC 的做法"
+
+**用户诉求**：hook 可以挂上，但默认不激活；只有用户调用 `/orca` skill 才介入
+
+**OMC/OMX 现状**：
+- OMC 注册了完整 hook 栈（UserPromptSubmit / SessionStart / PreToolUse / PostToolUse / Stop / SessionEnd 等 11 个事件），但 worker spawn 是按需的（用户显式调用 `/team` 才起 tmux pane）
+- OMX 也注册了 5 个 hook 事件（SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / Stop），但任务编排靠 skill 显式调用（`$ultrawork` / `$tdd` / `$plan`）
+- 两家本质都是「**全量 hook 注册 + 功能按需激活**」，hook 自身不是"按需"的
+
+**Orca 当前**：hook 一旦装上就持续生效（PreToolUse 等）
+
+**对应文件**：
+- `install.sh`（hook 注册）
+- `~/.claude/settings.json`（用户侧 hook 配置）
+
+---
+
+### 痛点 5：介入路径
+
+> Nick: "得让工头来介入啊，流水线工人那边不能随便介入的"
+> Nick: "偶尔我 codex 窗口出现 rm -rf 还是要等我授权确认的"
+> Nick: "大部分时候是托管"
+> Nick: "然后，流水线工人有时候我看他明显走偏了，我会直接打断介入，找工头还是延迟有点高"
+
+**用户诉求**：
+1. **大部分时候是托管**——Agent 自己跑，用户不干预
+2. **危险操作（rm -rf）保留 worker 自身的授权机制**——Codex 内置的确认弹窗不要被绕过
+3. **走偏纠正**——理论上应该回 lead pane 让 lead 转发，但**延迟太高**，所以用户实际会跳进 worker pane 直接打字
+4. 期望"工头介入"是一等公民路径，但要把延迟做下来
+
+**Orca 当前**：bridge 通信确实有延迟（read 5s + 心跳），用户跳 worker pane 是 workaround
+
+**对应文件**：
+- `skills/orca/SKILL.md`（lead/worker 协议、read 周期）
+- `tmux-bridge`（通信延迟优化）
+
+---
+
+### 痛点 6：`orca ps` 在 cc 内用不上
+
+> Nick: "Ps 都是在外面用的情况，但里面基本用不上，这也是我想用 Claude 来调用 orca 来做"
+
+**用户诉求**：`orca ps`（多实例多忘关）在 shell 外用得上，但 Agent 内基本用不上
+
+**用户期望**：让 Claude 在 cc 内自己调用 `orca ps` / `orca clean` 自动管理实例
+
+**对应文件**：
+- `orca` 主命令（ps、clean 子命令）
+- skill 暴露给 cc 调用
+
+---
+
+## 2. 优先级建议
+
+| 痛点 | 严重性 | 修复成本 | 优先级 |
+|---|---|---|---|
+| 1. 入口反了 | 极高（churn 直接原因） | 高（要重构入口范式） | **P0** |
+| 2. 强制 tmux 入侵 | 高（与 1 同源） | 高（同 1） | **P0** |
+| 3. 默认多 pane 太重 | 极高（"打破幻想"） | 中（改 start.sh 默认行为） | **P0** |
+| 4. hook 按需生效 | 中（解决了 1+2 自然好转） | 中 | **P1** |
+| 5. 介入路径 | 中（用户已有 workaround） | 中（bridge 通信优化） | **P1** |
+| 6. ps 在 cc 内用 | 低（已有 workaround） | 低（暴露 skill） | **P2** |
+
+---
+
+## 3. 对比 OMC/OMX 的范式落地
+
+| Nick 诉求 | OMC 怎么做 | OMX 怎么做 | Orca 应该怎么改 |
+|---|---|---|---|
+| Agent 内入口 | `/autopilot "..."` | `$ultrawork "..."` | `/orca dispatch "..."` skill |
+| 默认无 tmux | 默认在当前 shell 跑 cc | 默认在当前 shell 跑 codex | 默认不创建 tmux session |
+| 按需多 pane | `/team` 或 `omc team N:agent` | `omx team spawn` | `/orca team N` 显式调用才 spawn |
+| 工头介入 | OMC 主导（cc 是工头） | codex 是工头 | lead pane 收 worker 报告并可重新 dispatch |
+| 危险操作授权 | cc 自身机制 | codex 自身机制 | **不要拦截 worker 的原生确认** |
+| 多实例管理 | OMC 自动清理 | session 持久化 | `orca ps`/`clean` 暴露给 cc 调用 |
+
+---
+
+## 4. 落地路径草案
+
+### Phase 0：紧急修复入口范式（P0）
+
+1. 新增 `orca dispatch` skill，可在 cc/codex 内直接调用
+2. `start.sh` 加 `--no-tmux` 默认开关，单 pane 模式直接退化为"在当前 shell 起 cc"
+3. `start.sh` 默认只起 1 个 pane（lead），worker pane 按需 spawn
+4. install.sh 注册 hook 但默认 dormant（不主动 push 通知），用户调用 `/orca` 才激活通信流（OMC/OMX 是「全量注册 + 功能按需」，Orca 应学这个范式）
+
+### Phase 1：通信优化（P1）
+
+5. 缩短 `read` 默认延迟（5s → 1-2s 或事件驱动）
+6. 加 `orca worker spawn <agent>` 命令支持运行时增加 worker
+7. 加 `orca worker status` 让 lead 不用 read pane 也能查状态
+
+### Phase 2：自管理（P2）
+
+8. `orca ps` / `orca clean` 暴露给 cc 调用
+9. hook 自动检测僵尸 pane 并提示
+
+---
+
+## 5. 风险
+
+- **不破坏现有用户**：`orca` 命令仍能创建多 pane，只是默认变了；老用户用 `--legacy` 或显式参数能恢复
+- **嵌套问题**：tmux 内启动 cc，cc 的 hook 不要再触发 orca tmux 创建（需要环境变量探测，类似 `$TMUX` 检查）
+- **OMC 的强项是 19 unified agents 自动选**：Orca 不应该走"specialist 库"路线（差异化在异构 agent + 弱研发流程），所以入口范式抄 OMC，但 agent 设计仍走 lead/worker


### PR DESCRIPTION
## Summary

- 新增 `docs/research/competitor-analysis/` 目录，沉淀 Orca 与 OMC / OMX / ctx 三个参考项目的对比研究
- 14 维对比矩阵（含上手难度、日常顺畅性、可观测性、可介入性、自动通信连续性等使用者视角）
- Nick 的 UX 反馈拆解为 6 个痛点，标记 P0 churn 风险
- Orca 演进路线图：P0 入口范式重构 → P1 通信连续性 → P2 上下文持续性

## 文档结构

| 文件 | 内容 |
|---|---|
| `README.md` | 总览导航 |
| `comparison-matrix.md` | 14 节对比矩阵 + 修正记录 |
| `ux-issues.md` | Nick 反馈拆解 + 优先级 |
| `omc-deep-dive.md` | OMC 源码级实测 |
| `omx-deep-dive.md` | OMX 源码级实测 |
| `ctx-deep-dive.md` | ctx 借鉴价值分析 |
| `orca-evolution-proposal.md` | 三议题路线图 + 5 个待拍板问题 |

## 关键修正（与早期猜测不同）

- OMC 当前主 catalog 是 **19 unified agents**，不是宣传的 32
- OMX v2 已 **不再是 Claude bridge**（README 文案滞后）
- OMC Issue #716（默认 tmux 包装）**已 Closed**，文档口径已采纳
- OMC/OMX 都是「**全量 hook 注册 + 功能按需激活**」，而非"按需 hook"

## Test plan

纯文档变更，无需 build/test：
- [x] Markdown 链接和锚点检查 — 14 个相对链接全部解析 OK，无死链
- [x] 文档术语统一性 — `19 unified agents` 14 处一致；`32 specialists` / `Async Claude Code delegation` / `Claude bridge` 仅在修正记录与「过时口径」标注里出现
- [ ] 团队 review `orca-evolution-proposal.md` 第 7 节的 5 个待拍板问题（人工）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
