### PR TITLE
feat: 单 worker 关闭 worktree，多 worker 强制开启

### DIFF
--- a/skills/orca/SKILL.md
+++ b/skills/orca/SKILL.md
@@ -23,6 +23,7 @@ Read `$ORCA_ROLE`:
 | `ORCA_WORKER_ID` | - | `1`, `2`, ... |
 | `ORCA_ROOT` | repo root | repo root |
 | `ORCA_WORKFLOW` | workflow name (optional) | workflow name (optional) |
+| `ORCA_WORKTREE` | `0` or `1` | `0` or `1` |
 
 ## Workflow
 
@@ -54,7 +55,19 @@ tmux-bridge read $ORCA_PEER 5 && tmux-bridge message $ORCA_PEER "Read $msg_path"
 
 The `"Read $msg_path"` line uses double quotes intentionally — the body is a known-safe template (`Read ` + a controlled variable), so variable expansion is required and there is nothing else to escape. The single-quote default applies to free-form message content.
 
-## Worktree Filesystem Access
+## Filesystem Access
+
+### Worktree off (`ORCA_WORKTREE=0`)
+
+Workers read and edit files directly in `$ORCA_ROOT`. There is no filesystem isolation, so the lead must avoid editing the worker's scope while the worker is active. Workers do not commit in this mode; the lead reviews the final diff and handles any commit.
+
+| Operation | Path |
+|---|---|
+| Read or edit tracked files for the task | `$ORCA_ROOT/<path>` |
+| Install / build / test | run inside `$ORCA_ROOT` |
+| Local untracked files (`.env`, build outputs) | stay in `$ORCA_ROOT`; never reset or remove user-created files unless explicitly asked |
+
+### Worktree on (`ORCA_WORKTREE=1`)
 
 Worktrees share `.git` but have isolated working trees. Tracked files are checked out into every worktree; `.gitignored` resources (`node_modules/`, build outputs, `.env`, manually cloned reference repos under `docs/research/reference-repos/`) do not propagate.
 
@@ -71,10 +84,11 @@ See `docs/research/git-worktree-build-practices.md` for sources.
 ## Lead
 
 1. **Confirm** — discuss breakdown with user before dispatching
-2. **Dispatch** — for each worker, send: goal, scope, constraints, worktree path. End with: "Run /review, build, test. Fix issues, then report."
+2. **Dispatch** — for each worker, send: goal, scope, constraints, and working directory. End with: "Run /review, build, test. Fix issues, then report."
    - Single worker: use `$ORCA_PEER`
    - Multi-worker: iterate `$ORCA_WORKERS` (comma-separated), dispatch to each
-   - Worktree: run `orca-worktree create <slug>` first (`<slug>` = kebab-case feature name, e.g. `auth-refactor`; append `-<n>` only when multiple workers share that feature), then tell worker to `cd` into it
+   - If `ORCA_WORKTREE=1`: run `orca-worktree create <slug>` first (`<slug>` = kebab-case feature name, e.g. `auth-refactor`; append `-<n>` only when multiple workers share that feature), then tell worker to `cd` into it
+   - If `ORCA_WORKTREE=0`: do not create a worktree; tell worker to work directly in `$ORCA_ROOT`
    - Multi-line dispatches use file delivery (see Communication). Path-only message keeps worker context lean and survives compaction.
 3. **Wait** — say "dispatched, waiting" and **end turn**. Do not poll.
    - Heartbeat: `[orca]` idle notifications surface on lead's next tool use (PreToolUse hook). For immediate awareness, `tmux-bridge read <worker>` to check pane.
@@ -86,7 +100,8 @@ See `docs/research/git-worktree-build-practices.md` for sources.
 
 1. **Wait** — reply "Worker ready." in own pane (do not message lead) and end turn
 2. **Implement** -> **Self-review** (/review, fix, repeat) -> **Test** (build + tests)
-3. **Report** — 1-2 sentence summary to lead, no code/diffs (see Communication for inline vs file)
+3. **Commit** — only when `ORCA_WORKTREE=1` and the dispatch asks for it. When `ORCA_WORKTREE=0`, do not commit; leave the diff for the lead.
+4. **Report** — 1-2 sentence summary to lead, no code/diffs (see Communication for inline vs file)
 
 Workers can also initiate: ask lead for help or confirm approach.
 

--- a/skills/workflows/code/SKILL.md
+++ b/skills/workflows/code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orca-code
-description: Code workflow for Orca lead. Parallel implementation + merge + optimize.
+description: Code workflow for Orca lead. Parallel implementation + merge/commit + optimize.
 ---
 
 # Code Workflow
@@ -22,27 +22,32 @@ Confirm breakdown with user before dispatching.
 
 For each task, up to N workers (from `$ORCA_WORKERS`):
 
-```bash
-# 1. Create isolated worktree
-worktree_path=$(orca-worktree create task-1)
+When `ORCA_WORKTREE=1`, create a worktree first:
 
-# 2. Short tasks: inline in message
+```bash
+worktree_path=$(orca-worktree create task-1)
+```
+
+When `ORCA_WORKTREE=0`, skip worktree creation — workers use `$ORCA_ROOT` directly and must not commit. The lead reviews and commits the final diff.
+
+```bash
+# Short tasks: inline in message
 tmux-bridge read <worker> 5 && \
 tmux-bridge message <worker> "Task: <description>
-Worktree: cd $worktree_path
+Workdir: cd $worktree_path   # or $ORCA_ROOT when worktree is off
 Scope: <files to change>
 Criteria: <what done looks like>
 When done: /review, build, test. Fix issues, then report back." && \
 tmux-bridge read <worker> 5 && \
 tmux-bridge keys <worker> Enter
 
-# 3. Long-context tasks: write file, send pointer
+# Long-context tasks: write file, send pointer
 plan_path="/tmp/orca-handoff-task-1-$(date +%s).md"
 cat > "$plan_path" <<PLAN
 [full plan with all context, constraints, file refs]
 PLAN
 tmux-bridge message <worker> "Read $plan_path and execute.
-Worktree: cd $worktree_path
+Workdir: cd $worktree_path   # or $ORCA_ROOT when worktree is off
 When done: /review, build, test, then report back."
 ```
 
@@ -56,9 +61,11 @@ Say "Dispatched N workers, waiting." and **end turn**.
 
 Worker reports arrive via tmux-bridge message (push). Idle notifications surface on next tool use via heartbeat hook. Idle = no tool calls in 30s — could mean done, stuck, or waiting. Check worker pane to confirm.
 
-## 4. Merge
+## 4. Merge or Commit
 
-First-done-first-merge. For each completed worker:
+For each completed worker:
+
+### Worktree on (`ORCA_WORKTREE=1`)
 
 ```bash
 # Detect base branch
@@ -79,12 +86,29 @@ git commit -m "merge: task-1 from worker"
 orca-worktree remove task-1
 ```
 
-**Conflict handling:**
+### Worktree off (`ORCA_WORKTREE=0`)
+
+Workers edit `$ORCA_ROOT` directly and do not commit.
+
+```bash
+# Review the shared working tree
+git diff
+git status --short
+
+# Run /simplify on changed files, then inspect again.
+git diff
+
+# If clean:
+git add <changed-files>
+git commit -m "<type>: <description>"
+```
+
+**Conflict handling** (worktree mode only):
 - Merge in first-done-first-merge order
 - Use `--no-commit` to inspect before finalizing
 - Auto-resolve trivial conflicts (whitespace, import order)
 - Escalate semantic conflicts to user
-- After resolving, run `/review` on merged result before optimizing
+- After resolving, run `/review` on the integrated result before optimizing
 
 ## 5. Optimize
 

--- a/start.sh
+++ b/start.sh
@@ -23,7 +23,7 @@ case "${1:-}" in
   ""|-*) ;;  # no arg or flags → fall through to start logic
   *)
     echo "Error: unknown command '$1'" >&2
-    echo "Usage: orca [stop|idle|ps|rm|prune] [--workers N] [--lead MODEL] [--worker MODEL] [--workflow NAME]" >&2
+    echo "Usage: orca [stop|idle|ps|rm|prune] [--workers N] [--lead MODEL] [--worker MODEL] [--workflow NAME] [--worktree]" >&2
     exit 1
     ;;
 esac
@@ -37,6 +37,7 @@ WORKERS=1
 LEAD_MODEL="claude"
 WORKER_MODEL="codex"
 WORKFLOW=""
+WORKTREE=0
 START_ARGS_PASSED=false
 
 # --- Usage ---
@@ -56,6 +57,7 @@ Start options:
       --lead MODEL     Lead model: claude|codex|<binary> (default: claude)
       --worker MODEL   Worker model: claude|codex|<binary> (default: codex)
   -w, --workflow NAME  Workflow skill (sets ORCA_WORKFLOW)
+      --worktree       Use isolated git worktrees for workers
   -h, --help           Show this help
 EOF
 }
@@ -66,6 +68,7 @@ while [ $# -gt 0 ]; do
     --lead)        LEAD_MODEL="${2:?--lead requires a value}"; START_ARGS_PASSED=true; shift 2 ;;
     --worker)      WORKER_MODEL="${2:?--worker requires a value}"; START_ARGS_PASSED=true; shift 2 ;;
     -w|--workflow) WORKFLOW="${2:?--workflow requires a value}"; START_ARGS_PASSED=true; shift 2 ;;
+    --worktree)    WORKTREE=1; START_ARGS_PASSED=true; shift ;;
     -h|--help)     usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -153,6 +156,11 @@ if [ "${#existing[@]}" -gt 0 ]; then
   fi
 fi
 
+if [ "$WORKERS" -gt 1 ] && [ "$WORKTREE" -ne 1 ]; then
+  echo "Error: --worktree is required when --workers is greater than 1" >&2
+  exit 1
+fi
+
 SESSION="$(next_session_name "$WORKDIR")"
 # Per-instance dedicated tmux server: isolates orca from the user's main
 # tmux server so stop=kill-server gives a clean env on next start, and orca
@@ -176,6 +184,7 @@ echo "Starting $SESSION ..."
 echo "  Lead:    $LEAD_MODEL ($(model_cmd "$LEAD_MODEL"))"
 echo "  Worker:  $WORKER_MODEL ($(model_cmd "$WORKER_MODEL"))"
 echo "  Workers: $WORKERS"
+echo "  Worktree: $([ "$WORKTREE" = "1" ] && echo "on" || echo "off")"
 echo "  Dir:     $WORKDIR"
 [ -n "$WORKFLOW" ] && echo "  Workflow: $WORKFLOW"
 
@@ -243,7 +252,7 @@ launch_agent() {
 i=1
 for label in $WORKER_LABELS; do
   pane="$SESSION:main.${i}"
-  env_cmd="export ORCA=1 ORCA_ROLE=worker ORCA_PEER=${LEAD_LABEL} ORCA_WORKER_ID=${i} ORCA_ROOT=${WORKDIR} ORCA_SESSION=${SESSION}"
+  env_cmd="export ORCA=1 ORCA_ROLE=worker ORCA_PEER=${LEAD_LABEL} ORCA_WORKER_ID=${i} ORCA_ROOT=${WORKDIR} ORCA_SESSION=${SESSION} ORCA_WORKTREE=${WORKTREE}"
   [ -n "$WORKFLOW" ] && env_cmd="${env_cmd} ORCA_WORKFLOW=${WORKFLOW}"
   $TMUX_CMD send-keys -t "$pane" "$env_cmd" Enter
   launch_agent "$pane" "$WORKER_MODEL" "worker"
@@ -251,7 +260,7 @@ for label in $WORKER_LABELS; do
 done
 
 # --- Inject env + launch lead ---
-lead_env="export ORCA=1 ORCA_ROLE=lead ORCA_WORKERS=${WORKERS_CSV} ORCA_PEER=${FIRST_WORKER_LABEL} ORCA_ROOT=${WORKDIR} ORCA_SESSION=${SESSION}"
+lead_env="export ORCA=1 ORCA_ROLE=lead ORCA_WORKERS=${WORKERS_CSV} ORCA_PEER=${FIRST_WORKER_LABEL} ORCA_ROOT=${WORKDIR} ORCA_SESSION=${SESSION} ORCA_WORKTREE=${WORKTREE}"
 [ -n "$WORKFLOW" ] && lead_env="${lead_env} ORCA_WORKFLOW=${WORKFLOW}"
 $TMUX_CMD send-keys -t "$SESSION:main.0" "$lead_env" Enter
 launch_agent "$SESSION:main.0" "$LEAD_MODEL" "lead"


### PR DESCRIPTION
## 背景

Worktree 隔离对多 worker 并行是刚需（文件冲突、构建产物互扰），但在单 worker 场景下收益不高：没有并行写入风险，却要承担工作目录切换、`.gitignored` 资源不共享、构建产物隔离等额外复杂度。

本 PR 将 worktree 按场景分治：单 worker 关闭，多 worker 强制开启。

## 改动

### `start.sh`
- 新增 `--worktree` 启动参数（单 worker 默认关闭）
- 始终注入 `ORCA_WORKTREE=0` 或 `ORCA_WORKTREE=1` 到所有 pane（lead + worker）
- `--workers > 1` 未指定 `--worktree` 时拒绝启动并报错

### `skills/orca/SKILL.md`
- 环境变量表新增 `ORCA_WORKTREE`
- "Worktree Filesystem Access" 重命名为 "Filesystem Access"，拆分为 worktree off / on 两种模式
- Lead Dispatch 步骤按 `ORCA_WORKTREE` 条件化
- Worker 新增 Commit 步骤：仅 `ORCA_WORKTREE=1` 时提交，`=0` 时留 diff 给 lead

### `skills/workflows/code/SKILL.md`
- Dispatch 代码块改为文字条件描述
- Merge 步骤拆为 worktree on（merge 流程）/ worktree off（lead 直接 commit）
- Conflict handling 标注仅适用于 worktree 模式

## 与 E0 的兼容性

PR #20 / Issue #25 规划了 E0 重构（host agent 编排、删除 `start.sh`、inline/subagent/pane 三模式）。本 PR 的改动与 E0 方向兼容：

- `start.sh` 的修改会随 E0 自然消失
- `ORCA_WORKTREE` 环境变量和 skill 层的条件逻辑会延续到新模型中
- PR #20 设计文档中 "Worktree default ON" 的决策需要同步更新（见 Discussion #31 补充说明）

## 验证

- [x] `bash -n start.sh` 语法检查通过
- [x] `git diff --check` 无空白问题
- [x] `./start.sh --help` 正确显示 `--worktree`
- [x] `--workers 2` 无 `--worktree` 正确拒绝启动
- [x] SKILL.md 文档结构审查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)