### PR TITLE
docs: 同步 worktree opt-in 到各文档

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,4 +19,4 @@ docs/               → architecture decisions
 - English comments and output
 - Shell: `set -euo pipefail`, quote variables
 - Commits: `<type>: <description>`
-- Git in worktrees: prefer `git -C <repo-path>` over `cd <worktree> && git ...` for HEAD-affecting commands (`checkout`, `reset`, `merge`). A `cd` chain makes it trivial to mutate the wrong worktree's HEAD.
+- Git in worktrees (when `ORCA_WORKTREE=1`): prefer `git -C <repo-path>` over `cd <worktree> && git ...` for HEAD-affecting commands (`checkout`, `reset`, `merge`). A `cd` chain makes it trivial to mutate the wrong worktree's HEAD.

--- a/PLAN.md
+++ b/PLAN.md
@@ -42,7 +42,7 @@ Known issues:
 ## Target Architecture
 
 ```
-orca --lead claude --worker codex --workers 3 --workflow code
+orca --lead claude --worker codex --workers 3 --worktree --workflow code
 
 ┌─ lead (claude) ──────┬─ w1 (codex) ─┬─ w2 (codex) ─┬─ w3 (codex) ─┐
 │ dispatch + optimize  │ worktree/w1  │ worktree/w2  │ worktree/w3  │
@@ -50,6 +50,8 @@ orca --lead claude --worker codex --workers 3 --workflow code
 │ tmux-bridge          │ hooks + tmux │ hooks + tmux │ hooks + tmux │
 └──────────────────────┴──────────────┴──────────────┴──────────────┘
 ```
+
+Worktrees are used when `--worktree` is enabled; multi-worker mode requires it. Single-worker mode works directly in `$ORCA_ROOT` by default.
 
 ## P0: Multi-Worker + Isolation + Hooks
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Talk to the lead (left pane): `Have the coder write a hello world script`
 ### Multi-Worker
 
 ```bash
-orca --workers 3                           # 1 lead + 3 workers
-orca --workers 3 --workflow code           # with code workflow
+orca --workers 3 --worktree                # 1 lead + 3 workers
+orca --workers 3 --worktree --workflow code # with code workflow
 orca --lead claude --worker codex          # explicit models (default)
 orca --worker ./my-agent                   # custom binary as worker
 ```
 
-Workers get isolated git worktrees (`.orca/worktree/<slug>`) and heartbeat monitoring. Use a kebab-case feature slug such as `auth-refactor`; append `-<n>` only when multiple workers share the same feature.
+Single-worker mode works directly in `$ORCA_ROOT` by default. Worktrees (`.orca/worktree/<slug>`) are opt-in with `--worktree` and required for multi-worker. Heartbeat monitoring tracks worker idle state.
 
 See [design docs](docs/design/) for architecture details.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,13 +38,13 @@ orca stop               # 停止
 ### 多 Worker
 
 ```bash
-orca --workers 3                           # 1 lead + 3 workers
-orca --workers 3 --workflow code           # 使用 code workflow
+orca --workers 3 --worktree                # 1 lead + 3 workers
+orca --workers 3 --worktree --workflow code # 使用 code workflow
 orca --lead claude --worker codex          # 指定模型（默认值）
 orca --worker ./my-agent                   # 自定义 binary 做 worker
 ```
 
-Worker 使用独立 git worktree（`.orca/worktree/<slug>`）隔离，心跳机制监控 idle 状态。`<slug>` 使用 kebab-case feature 名称，例如 `auth-refactor`；只有多个 worker 处理同一 feature 时才追加 `-<n>`。
+单 worker 默认直接在 `$ORCA_ROOT` 工作。Worktree 通过 `--worktree` 可选启用，多 worker 必须启用，并使用 `.orca/worktree/<slug>` 配合心跳机制监控 idle 状态。
 
 架构详情见 [design docs](docs/design/)。
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,7 @@
 
 **Heartbeat via hooks** — no background monitor (deferred to P3). Workers write timestamps via PostToolUse hook (`.orca/heartbeat/<id>`). Lead checks heartbeats via PreToolUse hook, outputs `[orca]` notifications inline on next tool use. 30s cooldown per worker. Limitation: notifications only surface when lead is actively using tools.
 
-**On-demand worktrees** — `orca-worktree create/remove/list/clean` at `.orca/worktree/<slug>`. Slugs use kebab-case feature names, with optional `-<n>` only for same-feature multi-worker splits. Created by lead before dispatch, cleaned by `orca stop`.
+**On-demand worktrees** — enabled with `--worktree` and required for multi-worker; single-worker mode works in `$ORCA_ROOT` by default. `orca-worktree create/remove/list/clean` manages `.orca/worktree/<slug>`. Slugs use kebab-case feature names, with optional `-<n>` only for same-feature multi-worker splits. Created by lead before dispatch, cleaned by `orca stop`.
 
 **Handoff files** — long-context dispatch uses `/tmp/orca-handoff-<slug>-<timestamp>.md` instead of inline tmux-bridge messages. Survives truncation, context compaction, and worker restarts.
 


### PR DESCRIPTION
## 背景

PR #32 将 worktree 改为单 worker 关闭、多 worker 强制开启，但只改了 `start.sh` 和 skills 文档。其余文档仍按 worktree 始终开启描述，需要同步。

## 改动

| 文件 | 改动 |
|---|---|
| `PLAN.md` | 架构图命令加 `--worktree`，补充说明单/多 worker 行为 |
| `README.md` | 多 worker 示例加 `--worktree`，描述改为单 worker 默认在 `$ORCA_ROOT`，worktree opt-in |
| `README.zh-CN.md` | 同上中文版 |
| `docs/ARCHITECTURE.md` | On-demand worktrees 描述补充启用条件 |
| `AGENTS.md` | worktree git 规则标注适用于 `ORCA_WORKTREE=1` |

## 未改动

- `skills/` — 已在 PR #32 更新
- `docs/research/` — 历史研究文档
- `docs/design/` — 随 PR #20 单独更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)