### PR TITLE
feat:  提升 Claude Code 自动激活 /orca  的稳定性 + 改进 Lead/Worker 协作规则

### DIFF
--- a/skills/orca/SKILL.md
+++ b/skills/orca/SKILL.md
@@ -84,29 +84,37 @@ See `docs/research/git-worktree-build-practices.md` for sources.
 ## Lead
 
 1. **Confirm** — discuss breakdown with user before dispatching
-2. **Dispatch** — for each worker, send: goal, scope, constraints, and working directory. End with: "Run /review, build, test. Fix issues, then report."
+2. **Dispatch** — worker is an autonomous agent, not a dumb executor. Give enough context for independent judgment. Each dispatch must include:
+   - **Intent**: user's goal and why; quote critical constraints verbatim
+   - **Decisions**: key decisions and trade-offs with reasoning; flag unverified assumptions so worker knows what to check
+   - **Boundaries**: what NOT to do — explicit exclusions that prevent over-reach
+   - **Task**: specific goal, scope, and working directory
+   - End with: "Run /review. Build and test when applicable. Fix issues, then report."
    - Single worker: use `$ORCA_PEER`
    - Multi-worker: iterate `$ORCA_WORKERS` (comma-separated), dispatch to each
    - If `ORCA_WORKTREE=1`: run `orca-worktree create <slug>` first (`<slug>` = kebab-case feature name, e.g. `auth-refactor`; append `-<n>` only when multiple workers share that feature), then tell worker to `cd` into it
    - If `ORCA_WORKTREE=0`: do not create a worktree; tell worker to work directly in `$ORCA_ROOT`
    - Multi-line dispatches use file delivery (see Communication). Path-only message keeps worker context lean and survives compaction.
-3. **Wait** — say "dispatched, waiting" and **end turn**. Do not poll.
-   - Heartbeat: `[orca]` idle notifications surface on lead's next tool use (PreToolUse hook). For immediate awareness, `tmux-bridge read <worker>` to check pane.
-   - Idle = no tool calls in 30s. Could mean done, stuck, or waiting. Check worker pane to determine next action.
+3. **Wait** — say "dispatched, waiting" and **end turn**. Worker will message back when done.
+   - **No progress polling.** Do not use Monitor, sleep loops, or periodic `tmux-bridge read`.
+   - Heartbeat: `[orca]` idle notifications (no tool calls in 30s) surface passively via PreToolUse hook. Idle could mean done, stuck, or waiting.
+   - One-shot `tmux-bridge read <worker>` allowed only on: idle heartbeat, user request, worker message, or error/anomaly.
 4. **Optimize** — on report, /simplify changed files
 5. **Report** — summarize to user
 
 ## Worker
 
 1. **Wait** — reply "Worker ready." in own pane (do not message lead) and end turn
-2. **Implement** -> **Self-review** (/review, fix, repeat) -> **Test** (build + tests)
+2. **Implement** -> **Self-review** (/review, fix, repeat) -> **Test** (build + tests, when applicable)
+   - If dispatch lacks critical context (especially for destructive/broad changes), ask lead before proceeding.
+   - Do not read lead's pane to check lead's progress. Only run `tmux-bridge read <lead>` as the required read guard when sending a message.
 3. **Commit** — only when `ORCA_WORKTREE=1` and the dispatch asks for it. When `ORCA_WORKTREE=0`, do not commit; leave the diff for the lead.
-4. **Report** — 1-2 sentence summary to lead, no code/diffs (see Communication for inline vs file)
+4. **Report** — report once when done, blocked, or when a lead decision is needed to continue safely. Not after each step. 1-2 sentence summary, no code/diffs (see Communication for inline vs file).
 
-Workers can also initiate: ask lead for help or confirm approach.
+Workers can also initiate: ask lead for help or confirm approach — but only for decisions needed to proceed safely, not routine status updates.
 
 ## Rules
 
 1. Read before type/keys
 2. One `&&` chain per communication
-3. No polling — heartbeat handles idle detection
+3. No progress polling — lead: one-shot read only after idle/user/worker/error event; worker: read lead only as communication read guard

--- a/start.sh
+++ b/start.sh
@@ -265,14 +265,15 @@ lead_env="export ORCA=1 ORCA_ROLE=lead ORCA_WORKERS=${WORKERS_CSV} ORCA_PEER=${F
 $TMUX_CMD send-keys -t "$SESSION:main.0" "$lead_env" Enter
 launch_agent "$SESSION:main.0" "$LEAD_MODEL" "lead"
 
-# --- /clear re-activation monitor ---
+# --- /clear and /new re-activation monitor ---
 # After Codex /clear, monitor detects welcome screen and inputs the skill cmd.
 # User must press Enter manually (tmux can't send Enter to Codex ratatui TUI).
+# After Claude Code /new, monitor detects the product banner and submits /orca.
 _skill_monitor() {
   set +e
-  local session="$1" pane="$2" role="$3"
+  local session="$1" pane="$2" role="$3" agent_bin="$4"
   local skill_cmd
-  if [ "$role" = "worker" ]; then
+  if [ "$agent_bin" = "codex" ] && [ "$role" = "worker" ]; then
     # shellcheck disable=SC2016  # $orca is a literal codex skill command, not a variable
     skill_cmd='$orca'
   else
@@ -281,11 +282,19 @@ _skill_monitor() {
   while $TMUX_CMD has-session -t "$session" 2>/dev/null; do
     local out banner
     out=$($TMUX_CMD capture-pane -p -t "$pane" 2>/dev/null \
-      | perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g') || true
-    banner=$(echo "$out" | grep -c '>_ OpenAI Codex' || true)
+      | perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g') || true
+    case "$agent_bin" in
+      codex)  banner=$(echo "$out" | grep -c '>_ OpenAI Codex' || true) ;;
+      claude) banner=$(echo "$out" | grep -cE 'Claude Code v[0-9]' || true) ;;
+      *)      banner=0 ;;
+    esac
     if [ "$banner" -gt 0 ] && ! echo "$out" | grep -q "$skill_cmd"; then
       sleep 2
       $TMUX_CMD send-keys -l -t "$pane" "$skill_cmd"
+      if [ "$agent_bin" = "claude" ]; then
+        sleep 0.2
+        $TMUX_CMD send-keys -t "$pane" Enter
+      fi
     fi
     sleep 3
   done
@@ -298,20 +307,20 @@ for pid_file in /tmp/orca-monitor-"${SESSION}"-*.pid; do
   rm -f "$pid_file"
 done
 
-# --- Start monitors for codex panes ---
+# --- Start monitors for panes that need skill re-activation ---
 WORKER_BIN_CHECK="$(model_bin "$WORKER_MODEL")"
-if [ "$WORKER_BIN_CHECK" = "codex" ]; then
+if [ "$WORKER_BIN_CHECK" = "codex" ] || [ "$WORKER_BIN_CHECK" = "claude" ]; then
   i=1
   for label in $WORKER_LABELS; do
-    _skill_monitor "$SESSION" "$SESSION:main.${i}" "worker" &
+    _skill_monitor "$SESSION" "$SESSION:main.${i}" "worker" "$WORKER_BIN_CHECK" &
     echo $! > "/tmp/orca-monitor-${SESSION}-worker-${i}.pid"
     i=$((i + 1))
   done
 fi
 
 LEAD_BIN_CHECK="$(model_bin "$LEAD_MODEL")"
-if [ "$LEAD_BIN_CHECK" = "codex" ]; then
-  _skill_monitor "$SESSION" "$SESSION:main.0" "lead" &
+if [ "$LEAD_BIN_CHECK" = "codex" ] || [ "$LEAD_BIN_CHECK" = "claude" ]; then
+  _skill_monitor "$SESSION" "$SESSION:main.0" "lead" "$LEAD_BIN_CHECK" &
   echo $! > "/tmp/orca-monitor-${SESSION}-lead.pid"
 fi
 


### PR DESCRIPTION
## 概要

两个改进：修复 Claude Code 的 /orca 自动激活 + 改进多 Agent 协作规则。

---

### 1. Claude Code 自动激活 /orca

之前通过 SessionStart hook 轮询 Claude Code 的 prompt 字符来自动输入 /orca，Claude Code 更新后 TUI 渲染变了，正则匹配失败，自动激活挂了。

新方案完全自包含在 `start.sh`，不依赖 hook 或全局配置：
- 复用 Codex 已有的 `_skill_monitor` 机制，检测 `Claude Code v[0-9]` 产品 banner（比 prompt 字符稳定）
- banner 出现 + pane 里没有 `/orca` → 自动发送 `/orca` 并回车
- 初始启动和 `/new` 都走同一条路径
- Codex 原有行为不变

已验证：banner 正则匹配当前版本 (v2.1.132)，信任对话框不影响流程，`/new` 回到欢迎屏后正确重激活。

---

### 2. 改进 Lead/Worker 协作规则

使用中发现三个问题并修复：

**Lead 派活信息不够** → 要求带上完整上下文：用户意图、决策链路（区分已验证结论和未验证假设）、边界、具体任务。

**Lead 不停盯 Worker** → 禁止 Monitor / sleep / 周期性 read。只在心跳通知、用户指令、Worker 消息、异常时允许 read 一次。

**Worker 反向偷窥 + 逐步汇报** → 禁止 read Lead pane（发消息的 read guard 除外）。做完或需要决策时报告一次，不逐步汇报。缺关键上下文时主动问 Lead。

## 验证方式

- 自动激活：临时 tmux 实测通过，实际 orca 启动验证通过
- 协作规则：Lead/Worker 互相派发测试任务，验证双方遵守新规则

🤖 Generated with [Claude Code](https://claude.com/claude-code)