### PR TITLE
fix: TUI picker 原地刷新 + tmux copy-mode Esc 退出

### DIFF
--- a/_lib.sh
+++ b/_lib.sh
@@ -299,12 +299,22 @@ pick_one() {
   done
 }
 
+# Move cursor back to top-left of the TUI block (relative movement).
+# No-op on first call; sets _tui_rendered=1 so subsequent calls reposition.
+_tui_home() {
+  if [ "${_tui_rendered:-0}" -eq 1 ]; then
+    printf '\r'
+    tput cuu $((lines - 1))
+  fi
+  _tui_rendered=1
+}
+
 # TUI single-select renderer — file-scope, reads state via dynamic scope
 # from pick_one_tui's locals (prompt, hint, count, current, options).
 # Reuses _pick_many_clear (lines is set by the caller to match this layout).
 _pick_one_tui_render() {
   local row
-  tput rc
+  _tui_home
   printf '%s' "$prompt"
   tput el
   printf '\n'
@@ -356,11 +366,11 @@ pick_one_tui() {
     local current=0
     local lines=$((count + 1))
     [ -n "$hint" ] && lines=$((lines + 1))
+    local _tui_rendered=0
     local key extra
 
     trap '_pick_many_clear 2>/dev/null || true; tput cnorm 2>/dev/null || true' EXIT
 
-    tput sc
     tput civis
     _pick_one_tui_render
 
@@ -410,7 +420,7 @@ pick_one_tui() {
 # (prompt, hint, count, current, lines, selected, options).
 _pick_many_render() {
   local row marker
-  tput rc
+  _tui_home
   printf '%s' "$prompt"
   tput el
   printf '\n'
@@ -435,15 +445,18 @@ _pick_many_render() {
 }
 
 _pick_many_clear() {
+  [ "${_tui_rendered:-0}" -eq 1 ] || { tput cnorm; return 0; }
   local row
-  tput rc
+  printf '\r'
+  tput cuu $((lines - 1))
   for ((row = 0; row < lines; row++)); do
     tput el
     if [ "$row" -lt $((lines - 1)) ]; then
       tput cud1
     fi
   done
-  tput rc
+  printf '\r'
+  tput cuu $((lines - 1))
   tput cnorm
 }
 
@@ -472,6 +485,7 @@ pick_many_tui() {
     local current=0
     local lines=$((count + 1))
     [ -n "$hint" ] && lines=$((lines + 1))
+    local _tui_rendered=0
     local key extra output i
     local -a selected
     for ((i = 0; i < count; i++)); do
@@ -480,7 +494,6 @@ pick_many_tui() {
 
     trap '_pick_many_clear 2>/dev/null || true; tput cnorm 2>/dev/null || true' EXIT
 
-    tput sc
     tput civis
     _pick_many_render
 

--- a/start.sh
+++ b/start.sh
@@ -204,6 +204,10 @@ $TMUX_CMD select-layout -t "$SESSION:main" even-horizontal
 # --- tmux config ---
 $TMUX_CMD set-option -t "$SESSION" mode-keys vi
 $TMUX_CMD set-option -t "$SESSION" mouse on
+# Default Esc in copy-mode-vi is clear-selection (stays in copy-mode).
+# Rebind to cancel (exit copy-mode) so Esc reliably escapes stuck
+# sub-state prompts (jump/search/repeat) caused by pane redraws.
+$TMUX_CMD bind-key -T copy-mode-vi Escape send-keys -X cancel
 $TMUX_CMD bind-key Space select-layout even-horizontal
 # Pass through Kitty keyboard protocol (Ghostty/WezTerm/Kitty) so inner CLIs
 # can negotiate Shift+Enter etc. Without this tmux strips the modifiers.


### PR DESCRIPTION
## 概要

### 1. TUI picker 原地刷新
- 将 `_lib.sh` 中两个 TUI picker（单选/多选）的 `tput sc`/`tput rc`（绝对光标保存/恢复）替换为 `tput cuu N`（相对光标上移）
- 提取共享 `_tui_home()` helper，消除 3 处重复的光标重定位逻辑
- 在 `_pick_many_clear()` 中添加 early-return 保护，防止 EXIT trap 在首次渲染前触发时导致光标错位

**背景**：当 picker 列表靠近终端底部时，打印选项导致终端滚动，`tput sc`/`tput rc` 保存的绝对位置失效，每次按键都在上一个列表下方重新打印。相对光标移动不受滚动影响。

### 2. tmux copy-mode Esc 退出
- 在 orca tmux 会话中将 copy-mode-vi 的 Esc 从 `clear-selection` 改绑为 `cancel`（直接退出 copy-mode）

**背景**：在 orca 的 tmux 分屏中滚动浏览时，如果其他 pane 的 agent 有输出触发重绘，copy-mode 可能进入子状态 prompt（jump/search/repeat），Esc 默认只清除选区无法退出。改绑后 Esc 可靠地退出 copy-mode。

## 测试计划

- [x] 运行 `orca stop`，多会话时上下导航——列表应原地刷新
- [x] 运行 `orca`（启动/恢复），多会话时导航——同样效果
- [ ] 终端窗口缩小到足以触发滚动时测试
- [x] 在 orca tmux 会话中滚动进入 copy-mode，按 Esc 应直接退出
- [ ] 其他 pane 有输出时在 copy-mode 中按 Esc，应能可靠退出

🤖 Generated with [Claude Code](https://claude.com/claude-code)