### PR TITLE
docs: 移除 README 实验性标签

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Orca
 
-> **Experimental. NOT production-ready.**
-
 Multi-agent orchestrator — parallel AI agents with tmux + skills. Model-agnostic: any AI CLI as lead or worker.
 
 [中文](README.zh-CN.md) | English

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,5 @@
 # Orca
 
-> **实验性项目，未准备好用于生产。**
-
 多 agent 编排器 — 通过 tmux + skills 实现 AI agent 并行协作。模型无关：任意 AI CLI 可担任 lead 或 worker。
 
 [English](README.md) | 中文


### PR DESCRIPTION
## 概要

- 移除中英文 README 中的 "Experimental. NOT production-ready." / "实验性项目，未准备好用于生产。" 标签

## 背景

项目已具备完整的安装流程、多 worker 协作、worktree 隔离、tmux-bridge 通信、心跳机制、自动 skill 加载和测试覆盖，不再是实验阶段。

🤖 Generated with [Claude Code](https://claude.com/claude-code)